### PR TITLE
🎨 Palette: Add ARIA label to toggle favorite button

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" ToolTip="Toggle Favorite" AutomationProperties.Name="Toggle Favorite" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
### 💡 What
Added `AutomationProperties.Name` and `ToolTip` to the star ("★") toggle favorite button in `StaticPeerConfigWindow.xaml`.

### 🎯 Why
Icon-only buttons must have an accessible name for screen readers. A tooltip provides a visual hint for all users.

### 📸 Before/After
**Before:** `<Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>`
**After:** `<Button Content="★" ToolTip="Toggle Favorite" AutomationProperties.Name="Toggle Favorite" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>`

### ♿ Accessibility
Improved screen reader compatibility by explicitly defining the purpose of the toggle favorite button.

---
*PR created automatically by Jules for task [6068963226487906775](https://jules.google.com/task/6068963226487906775) started by @michaelleungadvgen*