### PR TITLE
🎨 Palette: Add AutomationProperties.Name to WPF XAML views for screen reader accessibility

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
@@ -33,10 +33,12 @@
                     <ui:Badge Appearance="Success" 
                               Content="{Binding ActiveAlertCount}"
                               ToolTip="Active alerts"
+                              AutomationProperties.Name="Active alerts"
                               Margin="0,0,5,0"/>
                     <ui:Badge Appearance="Caution" 
                               Content="{Binding TriggeredAlertCount}"
                               ToolTip="Triggered alerts"
+                              AutomationProperties.Name="Triggered alerts"
                               Visibility="{Binding TriggeredAlertCount, Converter={StaticResource CountToVisibilityConverter}}"
                               Margin="0,0,10,0"/>
                 </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
@@ -93,12 +93,12 @@
             <!-- Toolbar -->
             <ToolBarTray Grid.Row="0" Margin="0,0,0,10">
                 <ToolBar>
-                    <Button Content="🔄 Refresh" Command="{Binding RefreshCommand}" Padding="10,5"/>
+                    <Button Content="🔄 Refresh" Command="{Binding RefreshCommand}" Padding="10,5" AutomationProperties.Name="Refresh"/>
                     <Separator/>
-                    <Button Content="✓ Mark All Read" Command="{Binding MarkAsReadCommand}" Padding="10,5"/>
-                    <Button Content="🗑 Clear All" Command="{Binding ClearAllCommand}" Padding="10,5"/>
+                    <Button Content="✓ Mark All Read" Command="{Binding MarkAsReadCommand}" Padding="10,5" AutomationProperties.Name="Mark All Read"/>
+                    <Button Content="🗑 Clear All" Command="{Binding ClearAllCommand}" Padding="10,5" AutomationProperties.Name="Clear All"/>
                     <Separator/>
-                    <Button Content="✕ Close" Command="{Binding CloseCommand}" Padding="10,5" ToolTip="Close window (Esc)"/>
+                    <Button Content="✕ Close" Command="{Binding CloseCommand}" Padding="10,5" ToolTip="Close window (Esc)" AutomationProperties.Name="Close"/>
                 </ToolBar>
             </ToolBarTray>
 


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` to various badges and buttons in `PriceDropNotificationsWindow.xaml` and `PriceAlertWindow.xaml`.
🎯 Why: Screen readers cannot announce elements properly based solely on visual content or `ToolTip`s. `AutomationProperties.Name` provides explicit ARIA labels for WPF.
📸 Before/After: N/A (UI is visually identical)
♿ Accessibility: Fixes missing ARIA labels for buttons in WPF XAML views.

---
*PR created automatically by Jules for task [2822637132871205714](https://jules.google.com/task/2822637132871205714) started by @michaelleungadvgen*