### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure update execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-02-28 - Insecure Update Execution
+**Vulnerability:** The application update mechanism (`UpdateService`) downloaded an executable/MSI file from a remote URL and immediately executed it using `Process.Start` without cryptographically verifying the file's integrity.
+**Learning:** Automatically executing downloaded files based solely on an HTTP response is a critical supply chain risk. If the update server is compromised, attackers could serve a malicious payload which the application would blindly execute.
+**Prevention:** Always require and validate cryptographic hashes (e.g., SHA-256) of downloaded update payloads against a trusted manifest before execution. Delete any file that fails verification.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="updateResult">Update check result containing download URL and file hash</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,16 +167,16 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -186,6 +187,30 @@ public class UpdateService : IUpdateService
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");
+
+            // Validate file hash unconditionally
+            if (string.IsNullOrEmpty(updateResult.FileHash))
+            {
+                _logger.LogError("Security Error: No file hash provided in update manifest. Cannot securely verify the downloaded update.");
+                File.Delete(tempPath);
+                return false;
+            }
+
+            _logger.LogInfo("Verifying downloaded file hash...");
+            using var sha256 = SHA256.Create();
+            using var stream = File.OpenRead(tempPath);
+            var hashBytes = await sha256.ComputeHashAsync(stream);
+            var calculatedHash = Convert.ToHexString(hashBytes);
+
+            if (!calculatedHash.Equals(updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogError($"Security Error: Downloaded file hash ({calculatedHash}) does not match expected hash ({updateResult.FileHash}). The file may have been tampered with.");
+                stream.Close();
+                File.Delete(tempPath);
+                return false;
+            }
+
+            _logger.LogInfo("File hash verification successful.");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
## 🛡️ Sentinel Security Fix

**Severity:** CRITICAL
**Vulnerability:** The application's `UpdateService` downloaded remote update payloads (e.g., `.msi` or `.exe` files) and immediately executed them via `Process.Start` without performing any cryptographic integrity checks. 
**Impact:** A compromised update server or a Man-in-the-Middle (MitM) attacker could serve a malicious payload instead of the legitimate application update. The application would silently execute this malicious code, leading to total system compromise (Supply Chain Attack).
**Fix:** 
- Modified `IUpdateService` and `UpdateService` so that `DownloadUpdateAsync` accepts the full `UpdateCheckResult` object instead of just the download URL string.
- Added SHA-256 hash validation inside `DownloadUpdateAsync`.
- The method now unconditionally requires a `FileHash` to be present in the update manifest. If missing or if the computed hash of the downloaded file does not match the manifest hash, the update is rejected, the malicious file is deleted, and execution is aborted.
- Updated `UpdateNotificationWindow.xaml.cs` to pass the entire result object.

**Verification:**
- Confirmed the code modifications securely enforce SHA-256 validation.
- Ran `dotnet build` and `dotnet test` to ensure the project still compiles and no regressions were introduced.
- Added a Sentinel journal entry documenting this critical learning about supply chain security and execution validation.

---
*PR created automatically by Jules for task [13322042794917188458](https://jules.google.com/task/13322042794917188458) started by @michaelleungadvgen*