### PR TITLE
🎨 Palette: Add confirmation dialog for category deletion

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-05-23 - Destructive Action Confirmations
+**Learning:** Destructive actions, such as deleting a category, were performing instantly upon button click in the UI without a confirmation dialog. This can easily lead to accidental data loss or require annoying recovery steps.
+**Action:** Always wrap destructive operations (like deleting items or categories) with a simple user confirmation prompt (e.g., `MessageBox.Show` with `YesNo`) before proceeding with the operation.

--- a/AdvGenPriceComparer.WPF/ViewModels/CategoryViewModel.cs
+++ b/AdvGenPriceComparer.WPF/ViewModels/CategoryViewModel.cs
@@ -192,11 +192,20 @@ namespace AdvGenPriceComparer.WPF.ViewModels
                     return;
                 }
 
-                // Remove from list
-                Categories.Remove(SelectedCategory);
-                SelectedCategory = null;
+                var confirmResult = System.Windows.MessageBox.Show(
+                    $"Are you sure you want to delete the category '{SelectedCategory}'?\nThis action cannot be undone.",
+                    "Confirm Delete",
+                    System.Windows.MessageBoxButton.YesNo,
+                    System.Windows.MessageBoxImage.Question);
 
-                _logger.LogInfo("Category deleted successfully");
+                if (confirmResult == System.Windows.MessageBoxResult.Yes)
+                {
+                    // Remove from list
+                    Categories.Remove(SelectedCategory);
+                    SelectedCategory = null;
+
+                    _logger.LogInfo("Category deleted successfully");
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### 💡 What
Added a confirmation dialog before deleting a category.

### 🎯 Why
Destructive actions, such as deleting a category, were performing instantly upon button click in the UI without a confirmation dialog. This can easily lead to accidental data loss or require annoying recovery steps. This UX improvement adds a "safety net" for users so they don't accidentally click the "Delete Category" button and lose their data.

### 📸 Before/After
**Before:** Clicking "Delete Category" immediately deleted the category without any user prompt (unless there were items attached, which triggered a warning).
**After:** Clicking "Delete Category" triggers a standard confirmation dialog (`MessageBox.Show` with `YesNo` and a `Question` icon). The category is only deleted if the user explicitly confirms by clicking "Yes".

### ♿ Accessibility
The use of standard `System.Windows.MessageBox` ensures that the confirmation prompt is inherently accessible and recognized by screen readers and keyboard navigation in Windows.

---
*PR created automatically by Jules for task [10323561971717488059](https://jules.google.com/task/10323561971717488059) started by @michaelleungadvgen*