### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to close buttons in chat and search windows

### DIFF
--- a/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
@@ -112,7 +112,8 @@
                 </StackPanel>
 
                 <Button Grid.Column="1" 
-                        Content="✕" 
+                        Content="✕"
+                        AutomationProperties.Name="Close"
                         Width="30" 
                         Height="30"
                         Background="Transparent"

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -48,6 +48,7 @@
                 
                 <Button Grid.Column="1"
                         Content="✕"
+                        AutomationProperties.Name="Close"
                         Command="{Binding ClearSearchCommand}"
                         Width="40"
                         Height="40"


### PR DESCRIPTION
**What:** Added `AutomationProperties.Name="Close"` to the icon-only '✕' close buttons in `PriceChatWindow` and `GlobalSearchWindow`.
**Why:** Icon-only buttons without an explicit ARIA label fail to provide meaningful context to screen readers, causing them to simply announce "Button". Adding the `AutomationProperties.Name` ensures assistive technologies can correctly announce the button's purpose as "Close".
**Before/After:** No visual changes.
**Accessibility:** Improved screen reader accessibility for close buttons in chat and search windows by adding ARIA labels.

---
*PR created automatically by Jules for task [7278625714373621](https://jules.google.com/task/7278625714373621) started by @michaelleungadvgen*