### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to chat buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
@@ -308,6 +308,7 @@
                         Background="Transparent"
                         BorderThickness="0"
                         ToolTip="Clear chat"
+                        AutomationProperties.Name="Clear chat"
                         Command="{Binding ClearChatCommand}"/>
 
                 <Button Grid.Column="2"
@@ -319,6 +320,7 @@
                         Foreground="White"
                         BorderThickness="0"
                         ToolTip="Send message"
+                        AutomationProperties.Name="Send message"
                         Command="{Binding SendMessageCommand}">
                     <Button.Style>
                         <Style TargetType="Button">


### PR DESCRIPTION
💡 What: Added AutomationProperties.Name to the clear and send icon-only buttons in PriceChatWindow.
🎯 Why: Screen readers cannot announce these icon-only buttons, as ToolTips are insufficient.
📸 Before/After: N/A
♿ Accessibility: Screen reader users can now understand the purpose of the buttons in the chat interface.

---
*PR created automatically by Jules for task [5448745930275045498](https://jules.google.com/task/5448745930275045498) started by @michaelleungadvgen*