### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified update execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-03-29 - Unverified Update Execution
+**Vulnerability:** The application's auto-update mechanism (`UpdateService`) was downloading MSI installers directly to a temporary directory and executing them via `Process.Start()` without any cryptographic validation of the downloaded payload.
+**Learning:** Automatically executing downloaded binaries without verification opens the application to Man-in-the-Middle (MitM) attacks or compromised update servers. An attacker could replace the legitimate installer with a malicious payload, leading to remote code execution (RCE) with the privileges of the running application.
+**Prevention:** Always mandate cryptographic verification (e.g., SHA-256) of downloaded updates against a trusted manifest before execution. Fail securely: if the hash is missing or mismatched, the update must be rejected.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="updateResult">The update check result containing the download URL and expected file hash</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -166,16 +166,29 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (updateResult == null || string.IsNullOrWhiteSpace(updateResult.DownloadUrl))
+            {
+                _logger.LogError("Invalid update result or download URL.");
+                return false;
+            }
+
+            // Security: Mandate hash validation to prevent execution of unverified payloads
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update rejected: Missing file hash in update manifest.");
+                return false;
+            }
+
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -183,9 +196,23 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            // Verify the file hash before writing to disk and executing
+            using (var sha256 = System.Security.Cryptography.SHA256.Create())
+            {
+                var hashBytes = sha256.ComputeHash(data);
+                var hashString = Convert.ToHexString(hashBytes);
+
+                if (!hashString.Equals(updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update rejected: Downloaded file hash ({hashString}) does not match expected hash ({updateResult.FileHash}).");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
-            _logger.LogInfo($"Download completed: {tempPath}");
+            _logger.LogInfo($"Download completed and verified: {tempPath}");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `UpdateService` was downloading MSI installers directly to a temporary directory and executing them via `Process.Start()` without any cryptographic validation of the downloaded payload.
🎯 Impact: Unverified execution of downloaded binaries exposes the application to Man-in-the-Middle (MitM) attacks or compromised update servers. An attacker could replace the legitimate installer with a malicious payload, leading to remote code execution (RCE) with the privileges of the running application.
🔧 Fix: Modified `DownloadUpdateAsync` in `IUpdateService` and `UpdateService` to accept the full `UpdateCheckResult` instead of just the URL. Added logic to proactively compute the SHA-256 hash of the downloaded data and verify it against the `FileHash` provided in the update manifest before writing it to disk and executing it. The update is now securely rejected if the manifest missing the file hash or if the hash mismatches.
✅ Verification: Ensure the updated `AdvGenPriceComparer.WPF` compiles and `dotnet test -p:EnableWindowsTargeting=true --filter "Category!=WinUI"` passes without any new regressions. Wait for code review to sign off on the patch.

---
*PR created automatically by Jules for task [13958909937163592521](https://jules.google.com/task/13958909937163592521) started by @michaelleungadvgen*