### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified auto-update installation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-02-28 - Unverified Executable Downloads in Auto-Update Mechanism
+**Vulnerability:** The application's auto-update service downloaded MSI installer files from a remote URL provided in an update manifest and executed them blindly, without verifying their cryptographic integrity or authenticity.
+**Learning:** Blindly trusting network responses to download and execute installers, even over HTTPS, creates a massive attack surface. A compromised update server, or a MITM attack, could provide a malicious executable and easily achieve remote code execution (RCE) on client machines with high privileges.
+**Prevention:** Always verify the integrity of executable downloads before executing them using strong cryptographic hashes (like SHA-256) checked against a trusted source or manifest. Additionally, the mechanism must fail securely: if the hash is missing or mismatched, the update must be aborted.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
-    /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    /// <param name="result">The update check result containing the download URL and hash</param>
+    /// <returns>True if download started successfully and hash is valid</returns>
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult result);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,16 +167,28 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult result)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (result == null || string.IsNullOrWhiteSpace(result.DownloadUrl))
+            {
+                _logger.LogError("Update result or download URL is missing.");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(result.FileHash))
+            {
+                _logger.LogError("Update manifest is missing a file hash. Update rejected for security.");
+                return false;
+            }
+
+            _logger.LogInfo($"Starting download from: {result.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(result.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -183,6 +196,21 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            // Verify the file hash using SHA-256
+            using (var sha256 = System.Security.Cryptography.SHA256.Create())
+            {
+                var hashBytes = sha256.ComputeHash(data);
+                var downloadedHash = Convert.ToHexString(hashBytes);
+
+                if (!string.Equals(downloadedHash, result.FileHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Hash mismatch. Expected: {result.FileHash}, Actual: {downloadedHash}. Update rejected.");
+                    return false;
+                }
+            }
+            _logger.LogInfo("Hash verification passed.");
+
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: The application's auto-update mechanism downloaded and executed MSI installer files without verifying their integrity or authenticity.
* 🎯 Impact: This could allow a man-in-the-middle (MITM) attacker or a compromised update server to serve malicious executables, leading to remote code execution on the user's machine.
* 🔧 Fix: Modified `DownloadUpdateAsync` to require the full `UpdateCheckResult` payload. Added SHA-256 hash verification using `System.Security.Cryptography.SHA256` to ensure the downloaded file matches the expected hash provided in the update manifest. The update is securely rejected if the hash is missing, empty, or mismatched.
* ✅ Verification: Verified the code compiles successfully and the logic fails securely by reading the code. Run the test suite to ensure no regressions.

---
*PR created automatically by Jules for task [14278135342046816986](https://jules.google.com/task/14278135342046816986) started by @michaelleungadvgen*