### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to visual status badges

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-03-30 - WPF Visual Status Badge Accessibility
+**Learning:** Visual status indicators like `ui:Badge` used to show numerical counts (e.g., active alerts or unread notifications) require both a visual `ToolTip` and an explicitly defined `AutomationProperties.Name` attribute to be announced correctly by screen readers in WPF applications.
+**Action:** Always define `AutomationProperties.Name` and `ToolTip` on all visual status badges to ensure they provide necessary context to all users, including those using assistive technologies.

--- a/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
@@ -33,10 +33,12 @@
                     <ui:Badge Appearance="Success" 
                               Content="{Binding ActiveAlertCount}"
                               ToolTip="Active alerts"
+                              AutomationProperties.Name="Active alerts"
                               Margin="0,0,5,0"/>
                     <ui:Badge Appearance="Caution" 
                               Content="{Binding TriggeredAlertCount}"
                               ToolTip="Triggered alerts"
+                              AutomationProperties.Name="Triggered alerts"
                               Visibility="{Binding TriggeredAlertCount, Converter={StaticResource CountToVisibilityConverter}}"
                               Margin="0,0,10,0"/>
                 </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
@@ -32,6 +32,8 @@
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <ui:Badge Appearance="Danger" 
                               Content="{Binding UnreadCount}"
+                              ToolTip="Unread notifications"
+                              AutomationProperties.Name="Unread notifications"
                               Visibility="{Binding UnreadCount, Converter={StaticResource CountToVisibilityConverter}}"
                               Margin="0,0,10,0"/>
                     <ui:ToggleSwitch Content="Monitoring" 


### PR DESCRIPTION
### 💡 What:
Added explicit `AutomationProperties.Name` and visual `ToolTip` properties to `ui:Badge` controls used to display numerical counts in `PriceAlertWindow.xaml` and `PriceDropNotificationsWindow.xaml`.

### 🎯 Why:
Visual status badges that only contain numbers lack necessary context for screen reader users, who rely on underlying accessible names (ARIA labels) to announce the meaning of the element. ToolTips also provide visual users an additional cue if the meaning of the number isn't immediately obvious.

### 📸 Before/After:
**Before:** Screen readers would only announce a number (e.g., "5") when focusing on an alerts or notifications badge.
**After:** Screen readers announce the meaningful context (e.g., "Active alerts 5" or "Unread notifications 5").

### ♿ Accessibility:
Ensures critical status indicators are fully accessible via explicitly defined UI automation properties, acting as the WPF equivalent of web `aria-label` attributes.

---
*PR created automatically by Jules for task [11245997428214334031](https://jules.google.com/task/11245997428214334031) started by @michaelleungadvgen*