### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified installer execution in UpdateService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Unverified Executable Downloads
+**Vulnerability:** Downloaded update installers (MSI files) were being executed blindly via `Process.Start` without any file integrity checks.
+**Learning:** Even if the update manifest is downloaded over HTTPS, downloading and executing an unverified executable introduces severe risk. If the DNS is hijacked, or the update server/CDN is compromised, malicious payloads could be silently distributed and automatically run by users.
+**Prevention:** Always verify the cryptographic hash (e.g., SHA-256) of a downloaded executable against a known-good value provided in a trusted manifest before triggering execution. Ensure validation fails securely if the manifest hash is missing.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
-    /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    /// <param name="updateResult">The update check result containing the download URL and file hash</param>
+    /// <returns>True if download and verification succeeded and execution started</returns>
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -166,16 +166,16 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -186,6 +186,30 @@ public class UpdateService : IUpdateService
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");
+
+            // Verify file hash to prevent malicious update injection
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update verification failed: Missing FileHash in update manifest.");
+                if (File.Exists(tempPath)) File.Delete(tempPath);
+                return false;
+            }
+
+            string computedHashStr;
+            using (var sha256 = System.Security.Cryptography.SHA256.Create())
+            {
+                var hashBytes = sha256.ComputeHash(data);
+                computedHashStr = Convert.ToHexString(hashBytes);
+            }
+
+            if (!computedHashStr.Equals(updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogError($"Update verification failed: Hash mismatch. Expected {updateResult.FileHash}, got {computedHashStr}.");
+                if (File.Exists(tempPath)) File.Delete(tempPath);
+                return false;
+            }
+
+            _logger.LogInfo("Update cryptographically verified successfully.");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo
@@ -199,7 +223,7 @@ public class UpdateService : IUpdateService
         }
         catch (Exception ex)
         {
-            _logger.LogError("Failed to download update", ex);
+            _logger.LogError("Failed to download or verify update", ex);
             return false;
         }
     }

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL

💡 Vulnerability: Downloaded updates were executed without cryptographic verification. The UpdateService simply downloaded the .msi from the remote URL and blindly ran it.

🎯 Impact: MITM attacks or compromised update servers/CDNs could distribute malicious installers that are executed blindly with no integrity validation by the user's machine.

🔧 Fix: Enforced SHA-256 validation of the downloaded update against the `FileHash` provided in the `UpdateCheckResult` manifest. If the computed hash of the downloaded bytes doesn't match the manifest, or the manifest has no hash, the downloaded file is safely deleted and execution aborts.

✅ Verification: Run the test suite and verify updates fail securely when hashes mismatch. Also ran `dotnet build` with Windows targeting on the WPF project to ensure it builds correctly.

---
*PR created automatically by Jules for task [5974830877919496423](https://jules.google.com/task/5974830877919496423) started by @michaelleungadvgen*