### PR TITLE
🎨 Palette: Add confirmation prompt for category deletion

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-05-23 - Confirmation Prompts for Destructive Actions in WPF
+**Learning:** In WPF applications, it's crucial to wrap destructive actions (like deleting an item, store, or category) with a confirmation dialog. Not doing so allows users to accidentally delete data with a single click, leading to poor user experience. The application provides `MessageBox.Show(..., MessageBoxButton.YesNo, MessageBoxImage.Question)` for straightforward interactions.
+**Action:** Always add a confirmation prompt (`MessageBox.Show` with `YesNo` buttons) in ViewModel methods that execute deletion commands before performing the actual deletion.

--- a/AdvGenPriceComparer.WPF/ViewModels/CategoryViewModel.cs
+++ b/AdvGenPriceComparer.WPF/ViewModels/CategoryViewModel.cs
@@ -175,6 +175,15 @@ namespace AdvGenPriceComparer.WPF.ViewModels
                 if (string.IsNullOrWhiteSpace(SelectedCategory))
                     return;
 
+                var result = System.Windows.MessageBox.Show(
+                    $"Are you sure you want to delete the category '{SelectedCategory}'?\n\nThis action cannot be undone.",
+                    "Confirm Delete",
+                    System.Windows.MessageBoxButton.YesNo,
+                    System.Windows.MessageBoxImage.Question);
+
+                if (result != System.Windows.MessageBoxResult.Yes)
+                    return;
+
                 _logger.LogInfo($"Deleting category: {SelectedCategory}");
 
                 // Check if any items use this category


### PR DESCRIPTION
* 💡 **What:** Added a `MessageBox` confirmation prompt to the `DeleteCategory` method in `CategoryViewModel.cs`.
* 🎯 **Why:** Destructive actions without a confirmation dialog lead to accidental data loss. This change enforces a conscious decision from the user before a category is permanently deleted.
* 📸 **Before/After:** Before: Clicking 'Delete Category' instantly removed the category from the list. After: Clicking 'Delete Category' shows a `MessageBox` with Yes/No options asking to confirm the deletion.
* ♿ **Accessibility:** Prevents users (including those navigating with assistive technologies or keyboard-only access) from accidentally triggering irreversible data loss due to misclicks or incorrect focus.

---
*PR created automatically by Jules for task [18361342448863529914](https://jules.google.com/task/18361342448863529914) started by @michaelleungadvgen*