### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified update execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-02-28 - Unverified Executable Downloads in Auto-Updater
+**Vulnerability:** The application's auto-updater downloaded an `.msi` or `.exe` over HTTP/HTTPS and passed it directly to `Process.Start` without any integrity validation, leading to a critical Remote Code Execution (RCE) vulnerability if the update payload or manifest is intercepted or compromised.
+**Learning:** Developers often rely on TLS (HTTPS) for security, neglecting that DNS poisoning, malicious mirrors, or compromised upstream servers can still deliver malware. `Process.Start` on unverified binaries is extremely dangerous.
+**Prevention:** Always cryptographically verify downloaded installers before execution. Require an explicit `FileHash` (e.g., SHA-256) in the remote update manifest, fail securely if the hash is missing or empty, and compare the computed hash of the downloaded payload against the manifest hash using a constant-time or ordinal ignore-case comparison before allowing the process to start.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="updateResult">Update result containing download URL and hash</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Reflection;
 using System.Text.Json;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -166,16 +167,22 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Failed to download update: Update manifest is missing FileHash.");
+                return false;
+            }
+
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -183,9 +190,23 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            // Verify hash
+            using (var sha256 = SHA256.Create())
+            {
+                var computedHash = sha256.ComputeHash(data);
+                var computedHashString = Convert.ToHexString(computedHash);
+
+                if (!string.Equals(computedHashString, updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Failed to download update: Hash mismatch. Expected {updateResult.FileHash}, got {computedHashString}");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
-            _logger.LogInfo($"Download completed: {tempPath}");
+            _logger.LogInfo($"Download completed and verified: {tempPath}");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application downloaded and executed update installers over the network without verifying their integrity using cryptographic hashes. An attacker capable of intercepting the connection or modifying the remote update manifest could replace the installer with malware.
🎯 Impact: Remote code execution (RCE) on the user's system by executing a malicious installer with the user's privileges.
🔧 Fix: The update installer is now hashed via SHA-256 after download. The computed hash is compared to the `FileHash` property from the remote update manifest. If the hash does not match, or if the `FileHash` property is missing/empty in the manifest, the download fails and the installer is not executed.
✅ Verification: Run `dotnet test ./AdvGenPriceComparer.WPF --filter 'Category!=WinUI' -p:EnableWindowsTargeting=true` and `dotnet build ./AdvGenPriceComparer.WPF -p:EnableWindowsTargeting=true`.

---
*PR created automatically by Jules for task [1409709435003374929](https://jules.google.com/task/1409709435003374929) started by @michaelleungadvgen*