### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing hash validation on installer download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-04-01 - Critical Security Issue: Missing Hash Validation on Installer Download
+**Vulnerability:** The auto-update mechanism (`UpdateService.DownloadUpdateAsync`) was downloading MSI installers without verifying their cryptographic signatures against the manifest's `FileHash` before executing them (`Process.Start`).
+**Learning:** This exposes the application to Man-in-the-Middle (MITM) attacks and allows attackers to substitute malicious payloads for legitimate updates. Even with HTTPS, host compromise or intercept could result in Remote Code Execution (RCE) as the installer was blindly trusted.
+**Prevention:** Auto-update mechanisms must always cryptographically verify downloaded artifacts using a strong hash (e.g., SHA-256) defined in a secure manifest prior to execution. If validation fails securely (e.g., missing hash, incorrect hash), the update must be rejected.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
-    /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    /// <param name="updateResult">Update check result containing URL and hash</param>
+    /// <returns>True if download started successfully and hash verified</returns>
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -166,16 +166,28 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (updateResult == null || string.IsNullOrWhiteSpace(updateResult.DownloadUrl))
+            {
+                _logger.LogError("Invalid update result or download URL");
+                return false;
+            }
+
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
+
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update rejected: File hash is missing from update manifest.");
+                return false;
+            }
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -183,9 +195,22 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            using (var sha256 = System.Security.Cryptography.SHA256.Create())
+            {
+                var hashBytes = sha256.ComputeHash(data);
+                var actualHash = Convert.ToHexString(hashBytes);
+
+                if (!string.Equals(actualHash, updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update rejected: File hash mismatch. Expected {updateResult.FileHash}, got {actualHash}.");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
-            _logger.LogInfo($"Download completed: {tempPath}");
+            _logger.LogInfo($"Download completed and verified: {tempPath}");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The auto-update mechanism (`UpdateService.DownloadUpdateAsync`) was downloading MSI installers without verifying their cryptographic signatures against the manifest's `FileHash` before executing them (`Process.Start`).
🎯 Impact: This exposes the application to Man-in-the-Middle (MITM) attacks and allows attackers to substitute malicious payloads for legitimate updates. Even with HTTPS, host compromise or intercept could result in Remote Code Execution (RCE) as the installer was blindly trusted.
🔧 Fix: Updated `DownloadUpdateAsync` to require an `UpdateCheckResult` object. Before writing the downloaded file and executing it, its contents are hashed using `System.Security.Cryptography.SHA256` and matched case-insensitively using `Convert.ToHexString` against the `FileHash` in the update manifest. If the hash is missing or incorrect, the update is safely rejected and logged. Callers (`UpdateNotificationWindow.xaml.cs`) and interfaces (`IUpdateService.cs`) were updated accordingly. 
✅ Verification: `dotnet build` passes. Running `dotnet test` shows existing test suites pass. The changes explicitly verify the SHA-256 hash using the same payload.

---
*PR created automatically by Jules for task [6608834756745321552](https://jules.google.com/task/6608834756745321552) started by @michaelleungadvgen*