### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information exposure in error messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-02-28 - Information Exposure via Exception Messages
+**Vulnerability:** Internal error details (`ex.Message`), which could include stack traces, database schemas, or sensitive system information, were being returned to the client in HTTP 400 response payloads during API data uploads.
+**Learning:** Returning unhandled exception messages directly to clients is a common source of information leakage (CWE-209). This exposes internal architecture details that an attacker could use to craft more targeted attacks.
+**Prevention:** Catch generic exceptions and log the detailed error internally on the server side, but return a safe, generic error message (e.g., "An internal error occurred") to the client.

--- a/AdvGenPriceComparer.Server/Controllers/PricesController.cs
+++ b/AdvGenPriceComparer.Server/Controllers/PricesController.cs
@@ -58,7 +58,7 @@ public class PricesController : ControllerBase
             return BadRequest(new UploadResult
             {
                 Success = false,
-                ErrorMessage = $"Internal error: {ex.Message}"
+                ErrorMessage = "An internal error occurred while processing the request."
             });
         }
     }

--- a/AdvGenPriceComparer.Server/Services/PriceDataService.cs
+++ b/AdvGenPriceComparer.Server/Services/PriceDataService.cs
@@ -358,7 +358,7 @@ public class PriceDataService : IPriceDataService
         catch (Exception ex)
         {
             result.Success = false;
-            result.ErrorMessage = ex.Message;
+            result.ErrorMessage = "An internal error occurred while processing the upload.";
             session.IsSuccess = false;
             session.ErrorMessage = ex.Message;
             await _context.UploadSessions.AddAsync(session);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information exposure via exception messages in the `PricesController` and `PriceDataService`.
🎯 Impact: Internal error details, including stack traces or sensitive database information, could be leaked to the client.
🔧 Fix: Replaced `ex.Message` with generic error messages in API responses, while still logging the actual error and saving it to the database for debugging.
✅ Verification: Run `dotnet test --filter "Category!=WinUI" -p:EnableWindowsTargeting=true` to ensure all tests pass.

---
*PR created automatically by Jules for task [5386131742167877828](https://jules.google.com/task/5386131742167877828) started by @michaelleungadvgen*