### PR TITLE
🎨 Palette: Add AutomationProperties.Name to icon-only buttons in StaticPeerConfigWindow

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" AutomationProperties.Name="Toggle Favorite" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
* 💡 What: Added `AutomationProperties.Name` to the `★` (Favorite) button in the `StaticPeerConfigWindow`.
* 🎯 Why: Improves screen reader accessibility by providing descriptive text for icon-only buttons, allowing users relying on assistive technologies to understand the button's purpose instead of hearing ambiguous symbols.
* ♿ Accessibility: Screen readers will now announce "Toggle Favorite" instead of literal characters or nothing.

---
*PR created automatically by Jules for task [13679665998430862595](https://jules.google.com/task/13679665998430862595) started by @michaelleungadvgen*