### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified installer execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-03-06 - Unverified Installer Execution in Auto-Update
+**Vulnerability:** The WPF application's `UpdateService` downloaded updates and passed them to `Process.Start` without any cryptographic verification of the file. This allowed a Man-in-the-Middle (MitM) attacker or compromised update server to execute arbitrary code with the application's privileges by serving a malicious payload.
+**Learning:** Even when using HTTPS, update manifests and installer binaries can be spoofed or compromised. A defense-in-depth approach is critical for auto-update mechanisms.
+**Prevention:** Always include cryptographic hashes (like SHA-256) in the update manifest and explicitly verify the hash of the downloaded binary against the manifest's hash before execution. Furthermore, validate that the hash exists in the manifest to fail securely if an empty manifest is provided.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
-    /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    /// <param name="updateResult">The update result containing the download URL and hash</param>
+    /// <returns>True if download started successfully and verified</returns>
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,16 +167,22 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update rejected: FileHash is missing in update manifest.");
+                return false;
+            }
+
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -185,7 +192,26 @@ public class UpdateService : IUpdateService
             var data = await response.Content.ReadAsByteArrayAsync();
             await File.WriteAllBytesAsync(tempPath, data);
 
-            _logger.LogInfo($"Download completed: {tempPath}");
+            _logger.LogInfo($"Download completed: {tempPath}. Validating hash...");
+
+            string computedHash;
+            using (var sha256 = SHA256.Create())
+            {
+                using (var stream = File.OpenRead(tempPath))
+                {
+                    var hashBytes = sha256.ComputeHash(stream);
+                    computedHash = Convert.ToHexString(hashBytes);
+                }
+            }
+
+            if (!string.Equals(computedHash, updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogError($"Update rejected: Hash mismatch. Expected {updateResult.FileHash}, got {computedHash}");
+                File.Delete(tempPath);
+                return false;
+            }
+
+            _logger.LogInfo("Update hash validated successfully.");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The WPF application's `UpdateService` executed downloaded auto-update installers without cryptographic verification, relying purely on the HTTPS transfer.
🎯 **Impact:** If an attacker compromises the update URL or performs a sophisticated MitM attack, they could serve a malicious executable. Without hash validation, the application would blindly execute this payload, resulting in arbitrary code execution with the user's privileges.
🔧 **Fix:** Refactored `DownloadUpdateAsync` to accept the entire `UpdateCheckResult` object. Implemented explicit SHA-256 hash validation comparing the downloaded file's computed hash against the `FileHash` property in the manifest. If validation fails, or if the manifest omits the hash, the file is deleted and the update is securely rejected.
✅ **Verification:** Verified compilation and tested code paths ensuring correct SHA-256 logic, error handling, and file cleanup. Added journal entry documenting the missing validation.

---
*PR created automatically by Jules for task [16225271986690411389](https://jules.google.com/task/16225271986690411389) started by @michaelleungadvgen*