### PR TITLE
🎨 Palette: Add AutomationProperties.Name to icon buttons and badges

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/FavoritesWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/FavoritesWindow.xaml
@@ -183,6 +183,7 @@
                     <ui:Button Content="Remove Selected"
                                Command="{Binding RemoveFromFavoritesCommand}"
                                Icon="{ui:SymbolIcon Delete24}"
+                               AutomationProperties.Name="Remove Selected Favorites"
                                Appearance="Danger"
                                IsEnabled="{Binding CanRemoveFromFavorites}"/>
                 </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -48,6 +48,7 @@
                 
                 <Button Grid.Column="1"
                         Content="✕"
+                        AutomationProperties.Name="Close"
                         Command="{Binding ClearSearchCommand}"
                         Width="40"
                         Height="40"

--- a/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
@@ -32,10 +32,12 @@
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <ui:Badge Appearance="Success" 
                               Content="{Binding ActiveAlertCount}"
+                              AutomationProperties.Name="Active alerts count"
                               ToolTip="Active alerts"
                               Margin="0,0,5,0"/>
                     <ui:Badge Appearance="Caution" 
                               Content="{Binding TriggeredAlertCount}"
+                              AutomationProperties.Name="Triggered alerts count"
                               ToolTip="Triggered alerts"
                               Visibility="{Binding TriggeredAlertCount, Converter={StaticResource CountToVisibilityConverter}}"
                               Margin="0,0,10,0"/>

--- a/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
@@ -32,6 +32,8 @@
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <ui:Badge Appearance="Danger" 
                               Content="{Binding UnreadCount}"
+                              AutomationProperties.Name="Unread notifications count"
+                              ToolTip="Unread notifications"
                               Visibility="{Binding UnreadCount, Converter={StaticResource CountToVisibilityConverter}}"
                               Margin="0,0,10,0"/>
                     <ui:ToggleSwitch Content="Monitoring" 

--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" Padding="10,3" AutomationProperties.Name="Favorite" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
💡 What: Added AutomationProperties.Name to icon-only buttons (like ✕ and ★) and ui:Badges representing numerical counts.
🎯 Why: Screen readers cannot properly interpret symbol characters or custom UI components like badges without explicit textual names.
📸 Before/After: Buttons and badges lacked semantic meaning for screen readers. They now have explicit names like "Close", "Favorite", and "Unread notifications count".
♿ Accessibility: Ensures WPF components are fully accessible to screen reader users by providing proper AutomationProperties.Name attributes.

---
*PR created automatically by Jules for task [2187605189836671874](https://jules.google.com/task/2187605189836671874) started by @michaelleungadvgen*