### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing file hash validation in auto-updater

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Missing File Hash Verification on Auto-Update
+**Vulnerability:** The application's auto-update mechanism (`UpdateService`) downloaded updates and executed them via `Process.Start` without cryptographically verifying the downloaded file against the `FileHash` provided in the update manifest.
+**Learning:** Checking the version numbers and simply downloading a file is not enough; an attacker could use a Man-in-the-Middle (MITM) attack or compromise the update server to serve malicious installers. The downloaded artifact must be explicitly verified before execution.
+**Prevention:** Always cryptographically verify (e.g., using SHA-256) any downloaded executable or installer against a trusted manifest or signature before launching it. Fail securely if the hash is missing or mismatched.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="updateResult">The update check result containing the download URL and hash</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,16 +167,22 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update rejected: FileHash is missing in the update manifest.");
+                return false;
+            }
+
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -186,6 +193,33 @@ public class UpdateService : IUpdateService
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");
+
+            // Verify file hash
+            bool isHashValid = false;
+            using (var sha256 = SHA256.Create())
+            {
+                using (var stream = File.OpenRead(tempPath))
+                {
+                    var hashBytes = sha256.ComputeHash(stream);
+                    var computedHash = Convert.ToHexString(hashBytes);
+                    if (computedHash.Equals(updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        isHashValid = true;
+                    }
+                    else
+                    {
+                        _logger.LogError($"Update rejected: FileHash mismatch. Expected {updateResult.FileHash}, got {computedHash}");
+                    }
+                }
+            }
+
+            if (!isHashValid)
+            {
+                File.Delete(tempPath);
+                return false;
+            }
+
+            _logger.LogInfo("Update signature verified successfully.");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `UpdateService` downloaded application updates and blindly called `Process.Start` without cryptographically verifying the downloaded file against the `FileHash` specified in the update manifest.
🎯 Impact: An attacker who compromises the download URL, the update server, or intercepts the download via a Man-in-the-Middle (MITM) attack could serve a malicious installer which the application would execute, leading to full system compromise.
🔧 Fix: Updated `DownloadUpdateAsync` to accept the full `UpdateCheckResult` object. Implemented SHA-256 computation of the downloaded file and an `OrdinalIgnoreCase` string comparison against the expected `FileHash`. If the hash is missing or mismatched, the application logs an error, securely deletes the file, and aborts the update.
✅ Verification: `dotnet build` passes. Inspected the code to verify that file locks (`System.IO.IOException`) are prevented by scoping the `File.OpenRead` stream inside a `using` block that is disposed before attempting deletion.

---
*PR created automatically by Jules for task [9493078297729657961](https://jules.google.com/task/9493078297729657961) started by @michaelleungadvgen*