### PR TITLE
🎨 Palette: Add ARIA labels to emoji buttons for screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2024-05-23 - Accessibility of Emojis alongside Text in WPF buttons
+**Learning:** When using emojis alongside text in WPF button `Content` attributes (e.g., `Content="🔥 Best Prices"`), screen readers will announce the literal emoji descriptions along with the text (e.g., 'Fire Best Prices'). This makes the interface sound clunky and confusing to visually impaired users.
+**Action:** Always provide a text-only `AutomationProperties.Name` (e.g., `AutomationProperties.Name="Best Prices"`) to override the `Content` property for screen readers, preventing them from reading the literal emoji descriptions.

--- a/AdvGenPriceComparer.WPF/MainWindow.xaml
+++ b/AdvGenPriceComparer.WPF/MainWindow.xaml
@@ -205,7 +205,7 @@
 
                     <!-- Quick Actions -->
                     <TextBlock Text="Quick Actions" FontWeight="SemiBold" Margin="0,16,0,8" FontSize="12" Opacity="0.6"/>
-                    <ui:Button Content="🔍 Global Search" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🔍 Global Search" AutomationProperties.Name="Global Search" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding GlobalSearchCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
@@ -225,55 +225,55 @@
                            Command="{Binding ComparePricesCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🔥 Best Prices" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🔥 Best Prices" AutomationProperties.Name="Best Prices" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding BestPricesCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="⭐ Favorites" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="⭐ Favorites" AutomationProperties.Name="Favorites" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding FavoritesCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📷 Scan Barcode" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📷 Scan Barcode" AutomationProperties.Name="Scan Barcode" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding ScanBarcodeCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📢 Price Drop Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📢 Price Drop Alerts" AutomationProperties.Name="Price Drop Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding PriceDropNotificationsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🎯 Price Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🎯 Price Alerts" AutomationProperties.Name="Price Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding PriceAlertsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="⏰ Deal Reminders" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="⏰ Deal Reminders" AutomationProperties.Name="Deal Reminders" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding DealExpirationRemindersCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📰 Weekly Specials" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📰 Weekly Specials" AutomationProperties.Name="Weekly Specials" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding WeeklySpecialsDigestCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🛒 Shopping Lists" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🛒 Shopping Lists" AutomationProperties.Name="Shopping Lists" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding ShoppingListsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="⚙️ Settings" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="⚙️ Settings" AutomationProperties.Name="Settings" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding SettingsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🤖 ML Model Management" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🤖 ML Model Management" AutomationProperties.Name="ML Model Management" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding MLModelManagementCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📈 Price Forecast" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📈 Price Forecast" AutomationProperties.Name="Price Forecast" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding PriceForecastCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🎭 Detect Fake Sales" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🎭 Detect Fake Sales" AutomationProperties.Name="Detect Fake Sales" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding IllusoryDiscountDetectionCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="💬 AI Chat Assistant" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="💬 AI Chat Assistant" AutomationProperties.Name="AI Chat Assistant" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding ChatCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>


### PR DESCRIPTION
💡 **What**: Added `AutomationProperties.Name` overrides to all navigation buttons in `MainWindow.xaml` that use emojis in their `Content` string. Also updated `.Jules/palette.md` with this learning.
🎯 **Why**: When emojis are mixed with text in WPF button content, screen readers announce both the literal emoji name and the text (e.g. "Fire Best Prices", "Star Favorites"). Providing a clean text-only automation name prevents this clunky experience.
📸 **Before/After**: No visual changes.
♿ **Accessibility**: Significant improvement for screen reader users navigating the main menu, providing clean, text-only announcements for all buttons.

---
*PR created automatically by Jules for task [5046386964211687064](https://jules.google.com/task/5046386964211687064) started by @michaelleungadvgen*