### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix exception message leakage in API responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-03-07 - Exception Message Leakage in API Responses
+**Vulnerability:** The API controllers (`PricesController` and `PriceDataService`) were catching generic `Exception` objects and exposing their internal `ex.Message` directly in API responses (`UploadResult.ErrorMessage`).
+**Learning:** Exposing raw exception details can leak sensitive information to users, such as database connection strings, file paths, or backend logic details. This information could be exploited by malicious actors.
+**Prevention:** Always use generic error messages for client responses (e.g., "An internal error occurred"). Log the detailed exception information safely on the server side (e.g., using `ILogger`) and return safe HTTP error responses instead.

--- a/AdvGenPriceComparer.Server/Controllers/PricesController.cs
+++ b/AdvGenPriceComparer.Server/Controllers/PricesController.cs
@@ -58,7 +58,7 @@ public class PricesController : ControllerBase
             return BadRequest(new UploadResult
             {
                 Success = false,
-                ErrorMessage = $"Internal error: {ex.Message}"
+                ErrorMessage = "An internal error occurred during data upload."
             });
         }
     }

--- a/AdvGenPriceComparer.Server/Services/PriceDataService.cs
+++ b/AdvGenPriceComparer.Server/Services/PriceDataService.cs
@@ -358,7 +358,7 @@ public class PriceDataService : IPriceDataService
         catch (Exception ex)
         {
             result.Success = false;
-            result.ErrorMessage = ex.Message;
+            result.ErrorMessage = "An error occurred while processing the upload.";
             session.IsSuccess = false;
             session.ErrorMessage = ex.Message;
             await _context.UploadSessions.AddAsync(session);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The API controllers (`PricesController` and `PriceDataService`) were catching generic `Exception` objects and exposing their internal `ex.Message` directly in API HTTP responses (`UploadResult.ErrorMessage`).
🎯 **Impact:** Exposing raw exception details can leak sensitive backend information to clients, such as database connection strings, file paths, or internal logic details, which could be exploited by malicious actors.
🔧 **Fix:** Replaced internal exception messages with safe, generic HTTP error responses (e.g., "An internal error occurred during data upload") for the client while retaining server-side logging and internal database auditing of the actual exception.
✅ **Verification:** Verified via `dotnet build AdvGenPriceComparer.Server -p:Platform=x64` and test execution to ensure no regressions were introduced. Added learning entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10904052967111061354](https://jules.google.com/task/10904052967111061354) started by @michaelleungadvgen*