### PR TITLE
🎨 Palette: Add screen reader names to emoji buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2025-04-07 - Screen Reader Accessibility for Emoji Buttons
+**Learning:** Buttons using emojis combined with text (e.g. `Content="📁 Select Image File"`) or emojis alone (e.g. `Content="📋"`) in their `Content` property can be problematic for screen readers, as they may read out literal emoji descriptions instead of clear actions.
+**Action:** Always define a text-only `AutomationProperties.Name` on buttons that use emojis in their `Content` to ensure screen readers announce a clear, concise action.

--- a/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
@@ -73,7 +73,8 @@
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    Margin="0,0,0,15"/>
 
-                        <Button Content="📁 Select Image File" 
+                        <Button Content="📁 Select Image File"
+                                AutomationProperties.Name="Select Image File"
                                 Command="{Binding ScanFromFileCommand}"
                                 Padding="20,10"
                                 HorizontalAlignment="Left"
@@ -132,11 +133,13 @@
                                 <StackPanel Grid.Row="1" 
                                             Orientation="Horizontal" 
                                             Margin="0,10,0,0">
-                                    <Button Content="📋 Copy" 
+                                    <Button Content="📋 Copy"
+                                            AutomationProperties.Name="Copy"
                                             Command="{Binding CopyBarcodeCommand}"
                                             Padding="15,5"
                                             Margin="0,0,10,0"/>
-                                    <Button Content="🗑️ Clear" 
+                                    <Button Content="🗑️ Clear"
+                                            AutomationProperties.Name="Clear"
                                             Command="{Binding ClearScanCommand}"
                                             Padding="15,5"
                                             Style="{StaticResource DefaultButtonStyle}"/>
@@ -294,12 +297,14 @@
 
                         <!-- Action Buttons -->
                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                            <Button Content="⚙️ Generate" 
+                            <Button Content="⚙️ Generate"
+                                    AutomationProperties.Name="Generate"
                                     Command="{Binding GenerateBarcodeCommand}"
                                     Padding="20,10"
                                     Margin="0,0,10,0"
                                     Style="{StaticResource AccentButtonStyle}"/>
-                            <Button Content="🗑️ Clear" 
+                            <Button Content="🗑️ Clear"
+                                            AutomationProperties.Name="Clear"
                                     Command="{Binding ClearGenerateCommand}"
                                     Padding="20,10"
                                     Style="{StaticResource DefaultButtonStyle}"/>
@@ -334,7 +339,8 @@
                             </Grid>
                         </Border>
 
-                        <Button Content="💾 Save Barcode" 
+                        <Button Content="💾 Save Barcode"
+                                AutomationProperties.Name="Save Barcode"
                                 Command="{Binding SaveBarcodeCommand}"
                                 Padding="20,10"
                                 Margin="0,15,0,0"


### PR DESCRIPTION
💡 What: Added explicitly defined text-only `AutomationProperties.Name` to buttons that use emojis in their `Content` attribute within `ScanBarcodeWindow.xaml` and updated the learning journal.
🎯 Why: To prevent screen readers from reading literal emoji descriptions (e.g. "clipboard") and to provide a more intuitive accessible interface for assistive technology users.
♿ Accessibility: Improved screen reader accessibility for icon-based / emoji-based UI elements in `ScanBarcodeWindow.xaml`.

---
*PR created automatically by Jules for task [2857234432914729077](https://jules.google.com/task/2857234432914729077) started by @michaelleungadvgen*