### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified downloaded file execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Unverified Downloaded File Execution
+**Vulnerability:** The auto-update mechanism downloaded an MSI installer over the network and executed it using `Process.Start` without any cryptographic verification of the file's integrity.
+**Learning:** Downloading and executing binaries without verification allows for Man-in-the-Middle (MitM) attacks or server compromises to distribute malware to end-users. Even if downloaded over HTTPS, the server itself could be compromised.
+**Prevention:** Always cryptographically verify downloaded installers using a strong hash algorithm (e.g., SHA-256) against a known-good hash before execution. Also, use `UseShellExecute = false` and explicitly invoke the installer executable (e.g., `msiexec.exe` for MSIs) rather than relying on shell associations.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -29,7 +29,7 @@ public interface IUpdateService
     /// </summary>
     /// <param name="downloadUrl">URL to the installer</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,16 +167,21 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
+        var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update rejected: FileHash is missing or empty.");
+                if (File.Exists(tempPath)) File.Delete(tempPath);
+                return false;
+            }
 
-            // For MSI installers, we download to temp and execute
-            var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -185,21 +191,44 @@ public class UpdateService : IUpdateService
             var data = await response.Content.ReadAsByteArrayAsync();
             await File.WriteAllBytesAsync(tempPath, data);
 
-            _logger.LogInfo($"Download completed: {tempPath}");
+            _logger.LogInfo($"Download completed: {tempPath}. Verifying hash...");
+
+            using (var sha256 = SHA256.Create())
+            {
+                using (var stream = File.OpenRead(tempPath))
+                {
+                    var hashBytes = sha256.ComputeHash(stream);
+                    var calculatedHash = Convert.ToHexString(hashBytes);
+
+                    if (!string.Equals(calculatedHash, updateResult.FileHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogError($"Update rejected: Hash mismatch. Expected {updateResult.FileHash}, got {calculatedHash}.");
+                        stream.Close(); // explicit close to release file lock before deletion
+                        File.Delete(tempPath);
+                        return false;
+                    }
+                }
+            }
+
+            _logger.LogInfo("Hash verification successful.");
 
             // Execute the installer
             Process.Start(new ProcessStartInfo
             {
-                FileName = tempPath,
-                UseShellExecute = true,
-                Verb = "open"
+                FileName = "msiexec.exe",
+                Arguments = $"/i \"{tempPath}\"",
+                UseShellExecute = false
             });
 
             return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError("Failed to download update", ex);
+            _logger.LogError("Failed to download or verify update", ex);
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); } catch { }
+            }
             return false;
         }
     }

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application downloaded MSI installers for updates and executed them directly without verifying their integrity, and used UseShellExecute=true.
🎯 Impact: This could allow an attacker who compromises the update server or performs a MitM attack to execute arbitrary malicious code on the user's machine.
🔧 Fix: Updated the download mechanism to require an `UpdateCheckResult` containing the expected SHA256 hash. The downloaded file's hash is now verified before execution, and the installer is launched explicitly using `msiexec.exe` with `UseShellExecute = false`.
✅ Verification: The application builds and passes tests. Code inspection confirms the new hashing logic and secure process launch.

---
*PR created automatically by Jules for task [13159358556075714447](https://jules.google.com/task/13159358556075714447) started by @michaelleungadvgen*