### PR TITLE
🎨 Palette: Add ARIA names to icon-only and emoji buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
@@ -213,16 +213,16 @@
                     HorizontalAlignment="Right"
                     Margin="0,15,0,0">
             <Button Content="🔄 Refresh" 
-                    Command="{Binding RefreshCommand}"
+                    AutomationProperties.Name="Refresh reminders" Command="{Binding RefreshCommand}"
                     Style="{StaticResource SecondaryButtonStyle}"/>
             <Button Content="✓ Dismiss Selected" 
-                    Command="{Binding DismissDealCommand}"
+                    AutomationProperties.Name="Dismiss selected reminders" Command="{Binding DismissDealCommand}"
                     Style="{StaticResource ButtonStyle}"/>
             <Button Content="✓✓ Dismiss All" 
-                    Command="{Binding DismissAllCommand}"
+                    AutomationProperties.Name="Dismiss all reminders" Command="{Binding DismissAllCommand}"
                     Style="{StaticResource ButtonStyle}"/>
             <Button Content="🗑 Clear Dismissed" 
-                    Command="{Binding ClearDismissedCommand}"
+                    AutomationProperties.Name="Clear dismissed reminders" Command="{Binding ClearDismissedCommand}"
                     Style="{StaticResource SecondaryButtonStyle}"/>
         </StackPanel>
     </Grid>

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -48,7 +48,7 @@
                 
                 <Button Grid.Column="1"
                         Content="✕"
-                        Command="{Binding ClearSearchCommand}"
+                        AutomationProperties.Name="Clear search" Command="{Binding ClearSearchCommand}"
                         Width="40"
                         Height="40"
                         Background="Transparent"


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` to icon-only and emoji buttons in `GlobalSearchWindow.xaml` and `DealExpirationRemindersWindow.xaml`.
🎯 Why: Screen readers will read emojis literally (e.g., "Fire Best Prices" or just generic text) instead of their functional meaning. These changes improve accessibility for keyboard/screen reader users.
📸 Before/After: N/A
♿ Accessibility: Ensures buttons are read contextually by assistive technologies.

---
*PR created automatically by Jules for task [8139006102796219644](https://jules.google.com/task/8139006102796219644) started by @michaelleungadvgen*