### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Message Leakage in Upload API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-03-01 - Exception Message Leakage in API Endpoints
+**Vulnerability:** Raw exception messages (`ex.Message`) were returned directly to API clients in the `UploadData` endpoint of `PricesController` and `PriceDataService`.
+**Learning:** Returning `ex.Message` in HTTP responses is a common anti-pattern that can inadvertently expose sensitive internal details (like file paths, database constraints, or connection issues) to end users.
+**Prevention:** Always catch exceptions, log the detailed error securely on the server-side, and return a sanitized, generic error message to the client.

--- a/AdvGenPriceComparer.Server/Controllers/PricesController.cs
+++ b/AdvGenPriceComparer.Server/Controllers/PricesController.cs
@@ -58,7 +58,7 @@ public class PricesController : ControllerBase
             return BadRequest(new UploadResult
             {
                 Success = false,
-                ErrorMessage = $"Internal error: {ex.Message}"
+                ErrorMessage = "An error occurred while processing the upload request."
             });
         }
     }

--- a/AdvGenPriceComparer.Server/Services/PriceDataService.cs
+++ b/AdvGenPriceComparer.Server/Services/PriceDataService.cs
@@ -358,7 +358,7 @@ public class PriceDataService : IPriceDataService
         catch (Exception ex)
         {
             result.Success = false;
-            result.ErrorMessage = ex.Message;
+            result.ErrorMessage = "An internal error occurred during processing.";
             session.IsSuccess = false;
             session.ErrorMessage = ex.Message;
             await _context.UploadSessions.AddAsync(session);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Exception messages were being returned directly to clients via `ex.Message` in the upload endpoint, which can leak sensitive server-side internals, path info, or database schema details.
🎯 Impact: Attackers could gain knowledge of the application's internal workings, file structure, or dependencies, aiding in further exploitation.
🔧 Fix: Replaced `ex.Message` with safe, generic error messages in both the `PricesController` and `PriceDataService`. Detailed exception logging is preserved server-side.
✅ Verification: Code compiles successfully. The API now returns a generic error string upon internal errors, preventing leakage.

---
*PR created automatically by Jules for task [6489244623824519739](https://jules.google.com/task/6489244623824519739) started by @michaelleungadvgen*