### PR TITLE
🛡️ Sentinel: Prevent exception message leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Exception Message Leakage via API Responses
+**Vulnerability:** Raw exception messages (`ex.Message`) were returned directly in HTTP API responses (e.g., `UploadResult.ErrorMessage`) when errors occurred during data processing.
+**Learning:** Returning raw exceptions can expose sensitive internal information such as stack traces, database schemas, or filesystem paths to potentially malicious actors, giving them insights into backend infrastructure.
+**Prevention:** Catch generic exceptions and return opaque, safe error messages to the client (e.g., "An internal error occurred"). Log the detailed exception securely on the server side (e.g., via `ILogger` or an internal database record) for debugging purposes.

--- a/AdvGenPriceComparer.Server/Controllers/PricesController.cs
+++ b/AdvGenPriceComparer.Server/Controllers/PricesController.cs
@@ -58,7 +58,7 @@ public class PricesController : ControllerBase
             return BadRequest(new UploadResult
             {
                 Success = false,
-                ErrorMessage = $"Internal error: {ex.Message}"
+                ErrorMessage = "An internal error occurred during upload."
             });
         }
     }

--- a/AdvGenPriceComparer.Server/Services/PriceDataService.cs
+++ b/AdvGenPriceComparer.Server/Services/PriceDataService.cs
@@ -358,7 +358,7 @@ public class PriceDataService : IPriceDataService
         catch (Exception ex)
         {
             result.Success = false;
-            result.ErrorMessage = ex.Message;
+            result.ErrorMessage = "An internal error occurred while processing the upload.";
             session.IsSuccess = false;
             session.ErrorMessage = ex.Message;
             await _context.UploadSessions.AddAsync(session);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw exception messages were being leaked to users via the `/api/prices/upload` endpoint when an error occurred. This could expose internal stack traces, filesystem paths, or database structure.
🎯 Impact: Attackers could gain insights into the backend implementation or infrastructure details.
🔧 Fix: Replaced `ex.Message` with generic error messages like "An internal error occurred". The full exception is still securely captured in the database via the session record.
✅ Verification: Verifiable by code review ensuring `ex.Message` is not returned to clients in error payloads.

---
*PR created automatically by Jules for task [8682296506757305875](https://jules.google.com/task/8682296506757305875) started by @michaelleungadvgen*