### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified update installer execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-05-18 - Unverified Auto-Update Installer Execution
+**Vulnerability:** The auto-update mechanism downloaded the installer binary and executed it with `UseShellExecute = true` without verifying the integrity of the downloaded file.
+**Learning:** This Time-of-Check to Time-of-Use (TOCTOU) vulnerability can allow a man-in-the-middle or malicious host to provide a compromised installer that gets blindly executed.
+**Prevention:** Downloaded binaries must be verified using a cryptographic hash against an expected hash from a trusted source before saving to disk and executing. In addition, execution of the binary should be explicitly parameterized (e.g., calling msiexec) with `UseShellExecute = false`.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="updateResult">Update result containing download URL and hash</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,16 +167,29 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (updateResult == null || string.IsNullOrWhiteSpace(updateResult.DownloadUrl))
+            {
+                _logger.LogError("Invalid update result or download URL");
+                return false;
+            }
 
-            // For MSI installers, we download to temp and execute
-            var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update rejected securely: FileHash is missing in update manifest.");
+                return false;
+            }
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
+
+            var isMsi = updateResult.DownloadUrl.EndsWith(".msi", StringComparison.OrdinalIgnoreCase);
+            var extension = isMsi ? ".msi" : ".exe";
+            var tempPath = Path.Combine(Path.GetTempPath(), $"AdvGenPriceComparer_Update{extension}");
+
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -183,17 +197,46 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            // Perform cryptographic hash validation
+            using (var sha256 = SHA256.Create())
+            {
+                var hashBytes = sha256.ComputeHash(data);
+                var downloadedHash = Convert.ToHexString(hashBytes);
+
+                var expectedHash = updateResult.FileHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase)
+                    ? updateResult.FileHash.Substring(7)
+                    : updateResult.FileHash;
+
+                if (!string.Equals(downloadedHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update rejected securely: FileHash mismatch. Expected {expectedHash}, got {downloadedHash}.");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
-            _logger.LogInfo($"Download completed: {tempPath}");
+            _logger.LogInfo($"Download completed and hash verified: {tempPath}");
 
-            // Execute the installer
-            Process.Start(new ProcessStartInfo
+            // Execute the installer securely
+            if (isMsi)
             {
-                FileName = tempPath,
-                UseShellExecute = true,
-                Verb = "open"
-            });
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "msiexec.exe",
+                    Arguments = $"/i \"{tempPath}\"",
+                    UseShellExecute = false
+                });
+            }
+            else
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = tempPath,
+                    UseShellExecute = false
+                });
+            }
 
             return true;
         }

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The update mechanism downloaded a binary installer and executed it blindly using `Process.Start` with `UseShellExecute = true`, leaving the application open to Man-in-the-Middle (MitM) attacks where a malicious installer could be substituted. The code assumed an `.msi` extension without enforcing execution semantics.
🎯 Impact: A malicious actor could execute arbitrary code on the user's system by intercepting the update download and returning a payload.
🔧 Fix: Added cryptographic hash validation (SHA256) of the downloaded bytes against a trusted manifest before saving to disk. Adjusted the execution flow to explicitly call `msiexec.exe` with `UseShellExecute = false` for `.msi` installers while allowing regular, explicit `.exe` execution, and handled potential `sha256:` prefixing on the hash.
✅ Verification: `dotnet build AdvGenPriceComparer.sln -p:EnableWindowsTargeting=true` builds cleanly. `dotnet test AdvGenPriceComparer.sln --filter "Category!=WinUI" -p:EnableWindowsTargeting=true` runs successfully.

---
*PR created automatically by Jules for task [6404791174147219090](https://jules.google.com/task/6404791174147219090) started by @michaelleungadvgen*