### PR TITLE
🎨 Palette: Add AutomationProperties.Name to emoji buttons for screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2025-05-23 - WPF Icon-only Button Accessibility
+**Learning:** Screen readers announce the literal emoji descriptions (e.g. "Fire Best Prices") which degrades the user experience. By setting `AutomationProperties.Name`, we provide text-only accessible names.
+**Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.

--- a/AdvGenPriceComparer.WPF/Views/TripOptimizerWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/TripOptimizerWindow.xaml
@@ -67,7 +67,7 @@
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                    <Button Content="🔄 Refresh" 
+                    <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh"
                             Command="{Binding RefreshListsCommand}"
                             Padding="12,8" Margin="0,0,8,0"
                             Background="#FFFFFF" Foreground="#0D6EFD" BorderThickness="0"/>
@@ -434,11 +434,11 @@
                            VerticalAlignment="Center"/>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <Button Content="📋 Copy to Clipboard"
+                    <Button Content="📋 Copy to Clipboard" AutomationProperties.Name="Copy to Clipboard"
                             Command="{Binding ExportResultsCommand}"
                             Padding="12,8" Margin="0,0,8,0"
                             Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                    <Button Content="🖨️ Print"
+                    <Button Content="🖨️ Print" AutomationProperties.Name="Print"
                             Command="{Binding PrintResultsCommand}"
                             Padding="12,8"
                             Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}"/>

--- a/AdvGenPriceComparer.WPF/Views/WeeklySpecialsDigestWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/WeeklySpecialsDigestWindow.xaml
@@ -233,16 +233,16 @@
                     Orientation="Horizontal" 
                     HorizontalAlignment="Right"
                     Margin="0,15,0,0">
-            <Button Content="🔄 Refresh" 
+            <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh"
                     Command="{Binding GenerateDigestCommand}"
                     Style="{StaticResource SecondaryButtonStyle}"/>
-            <Button Content="📋 Copy" 
+            <Button Content="📋 Copy" AutomationProperties.Name="Copy"
                     Command="{Binding CopyToClipboardCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="📝 Export Markdown" 
+            <Button Content="📝 Export Markdown" AutomationProperties.Name="Export Markdown"
                     Command="{Binding ExportMarkdownCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="📄 Export Text" 
+            <Button Content="📄 Export Text" AutomationProperties.Name="Export Text"
                     Command="{Binding ExportTextCommand}"
                     Style="{StaticResource ButtonStyle}"/>
         </StackPanel>


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` to icon/emoji buttons in `TripOptimizerWindow.xaml` and `WeeklySpecialsDigestWindow.xaml`.
🎯 Why: Screen readers announce the literal emoji descriptions (e.g. "Fire Best Prices") which degrades the user experience. By setting `AutomationProperties.Name`, we provide text-only accessible names.
📸 Before/After: Not applicable (invisible UX/a11y change).
♿ Accessibility: Improves screen reader support for icon-based action buttons in WPF views.

---
*PR created automatically by Jules for task [9964478755981374525](https://jules.google.com/task/9964478755981374525) started by @michaelleungadvgen*