### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified update execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2024-05-18 - Missing Integrity Validation on Updates
+**Vulnerability:** The application downloaded an auto-update payload and executed it via `Process.Start(tempPath)` with `UseShellExecute = true` without performing any cryptographic hash validation, opening it up to man-in-the-middle code execution. Furthermore, it did not distinguish `msiexec` executions securely.
+**Learning:** Checking hashes *after* writing the file opens a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the file can be swapped before execution. The `FileHash` often includes dynamic prefixes like `sha256:` that must be explicitly stripped before parsing, and executing `.msi` installers securely requires `msiexec.exe /i` with `UseShellExecute = false`.
+**Prevention:** Always verify downloaded file bytes cryptographically *in-memory* against a known good hash from the manifest prior to flushing to disk, and always execute known binaries safely with explicit process arguments rather than relying on system shell handlers.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -29,7 +29,7 @@ public interface IUpdateService
     /// </summary>
     /// <param name="downloadUrl">URL to the installer</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -166,16 +166,19 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            if (string.IsNullOrWhiteSpace(updateResult.FileHash))
+            {
+                _logger.LogError("Update rejected: FileHash is missing or empty.");
+                return false;
+            }
 
-            // For MSI installers, we download to temp and execute
-            var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -183,17 +186,56 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            using (var sha256 = System.Security.Cryptography.SHA256.Create())
+            {
+                var hashBytes = sha256.ComputeHash(data);
+                var computedHash = Convert.ToHexString(hashBytes);
+
+                var expectedHash = updateResult.FileHash.Trim();
+                if (expectedHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
+                {
+                    expectedHash = expectedHash.Substring(7);
+                }
+
+                if (!string.Equals(computedHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update rejected: Hash mismatch. Expected {expectedHash}, got {computedHash}.");
+                    return false;
+                }
+            }
+
+            string extension = Path.GetExtension(updateResult.DownloadUrl);
+            if (string.IsNullOrEmpty(extension) || (!extension.Equals(".msi", StringComparison.OrdinalIgnoreCase) && !extension.Equals(".exe", StringComparison.OrdinalIgnoreCase)))
+            {
+                extension = ".msi";
+            }
+
+            var tempPath = Path.Combine(Path.GetTempPath(), $"AdvGenPriceComparer_Update{extension}");
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");
 
-            // Execute the installer
-            Process.Start(new ProcessStartInfo
+            ProcessStartInfo startInfo;
+            if (extension.Equals(".msi", StringComparison.OrdinalIgnoreCase))
             {
-                FileName = tempPath,
-                UseShellExecute = true,
-                Verb = "open"
-            });
+                startInfo = new ProcessStartInfo
+                {
+                    FileName = "msiexec.exe",
+                    Arguments = $"/i \"{tempPath}\"",
+                    UseShellExecute = false
+                };
+            }
+            else
+            {
+                startInfo = new ProcessStartInfo
+                {
+                    FileName = tempPath,
+                    UseShellExecute = false
+                };
+            }
+
+            Process.Start(startInfo);
 
             return true;
         }

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Missing integrity check for downloaded auto-update installers and insecure Process execution with UseShellExecute=true.
🎯 Impact: A man-in-the-middle or DNS hijack could supply a malicious executable which the app would blindly run.
🔧 Fix: Implement strictly matched in-memory TOCTOU-safe SHA-256 verification against the manifest, strictly enforce UseShellExecute=false, and correctly invoke msiexec for MSIs.
✅ Verification: Trigger an update download; ensure the installer is executed securely only if its hash perfectly matches the payload manifest.

---
*PR created automatically by Jules for task [7739196485575255349](https://jules.google.com/task/7739196485575255349) started by @michaelleungadvgen*