### PR TITLE
🎨 Palette: Improve screen reader accessibility for emoji buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-04-12 - WPF Emoji Button Accessibility
+**Learning:** In WPF applications, buttons containing emojis alongside text in their `Content` properties (e.g., `Content="🔄 Refresh"`) can cause screen readers to announce the literal emoji descriptions (e.g., 'Counterclockwise arrows button Refresh').
+**Action:** Always define `AutomationProperties.Name` on buttons containing emojis to override the default content readout and ensure a clean, text-only announcement of the button's intent to screen readers.

--- a/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
@@ -214,16 +214,20 @@
                     Margin="0,15,0,0">
             <Button Content="🔄 Refresh" 
                     Command="{Binding RefreshCommand}"
-                    Style="{StaticResource SecondaryButtonStyle}"/>
+                    Style="{StaticResource SecondaryButtonStyle}"
+                    AutomationProperties.Name="Refresh"/>
             <Button Content="✓ Dismiss Selected" 
                     Command="{Binding DismissDealCommand}"
-                    Style="{StaticResource ButtonStyle}"/>
+                    Style="{StaticResource ButtonStyle}"
+                    AutomationProperties.Name="Dismiss Selected"/>
             <Button Content="✓✓ Dismiss All" 
                     Command="{Binding DismissAllCommand}"
-                    Style="{StaticResource ButtonStyle}"/>
+                    Style="{StaticResource ButtonStyle}"
+                    AutomationProperties.Name="Dismiss All"/>
             <Button Content="🗑 Clear Dismissed" 
                     Command="{Binding ClearDismissedCommand}"
-                    Style="{StaticResource SecondaryButtonStyle}"/>
+                    Style="{StaticResource SecondaryButtonStyle}"
+                    AutomationProperties.Name="Clear Dismissed"/>
         </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
💡 What: Added text-only `AutomationProperties.Name` attributes to the action buttons in the Deal Expiration Reminders window.
🎯 Why: The buttons contain emojis (🔄, ✓, 🗑) alongside text in their `Content` properties. Without `AutomationProperties.Name`, screen readers would announce the literal emoji descriptions (e.g., 'Counterclockwise arrows button Refresh'), which degrades the experience for assistive technology users.
♿ Accessibility: Ensures that screen readers cleanly announce the button's intent (e.g., 'Refresh' or 'Clear Dismissed') by overriding the default content readout.

---
*PR created automatically by Jules for task [7744434126934960036](https://jules.google.com/task/7744434126934960036) started by @michaelleungadvgen*