### PR TITLE
🎨 Palette: Add screen reader names to emoji buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/MainWindow.xaml
+++ b/AdvGenPriceComparer.WPF/MainWindow.xaml
@@ -205,7 +205,7 @@
 
                     <!-- Quick Actions -->
                     <TextBlock Text="Quick Actions" FontWeight="SemiBold" Margin="0,16,0,8" FontSize="12" Opacity="0.6"/>
-                    <ui:Button Content="🔍 Global Search" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🔍 Global Search" AutomationProperties.Name="Global Search" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding GlobalSearchCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
@@ -225,7 +225,7 @@
                            Command="{Binding ComparePricesCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🔥 Best Prices" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🔥 Best Prices" AutomationProperties.Name="Best Prices" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding BestPricesCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
@@ -233,15 +233,15 @@
                            Command="{Binding FavoritesCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📷 Scan Barcode" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📷 Scan Barcode" AutomationProperties.Name="Scan Barcode" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding ScanBarcodeCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📢 Price Drop Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📢 Price Drop Alerts" AutomationProperties.Name="Price Drop Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding PriceDropNotificationsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🎯 Price Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🎯 Price Alerts" AutomationProperties.Name="Price Alerts" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding PriceAlertsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
@@ -249,31 +249,31 @@
                            Command="{Binding DealExpirationRemindersCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📰 Weekly Specials" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📰 Weekly Specials" AutomationProperties.Name="Weekly Specials" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding WeeklySpecialsDigestCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🛒 Shopping Lists" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🛒 Shopping Lists" AutomationProperties.Name="Shopping Lists" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding ShoppingListsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="⚙️ Settings" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="⚙️ Settings" AutomationProperties.Name="Settings" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding SettingsCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🤖 ML Model Management" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🤖 ML Model Management" AutomationProperties.Name="ML Model Management" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding MLModelManagementCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="📈 Price Forecast" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="📈 Price Forecast" AutomationProperties.Name="Price Forecast" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding PriceForecastCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="🎭 Detect Fake Sales" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="🎭 Detect Fake Sales" AutomationProperties.Name="Detect Fake Sales" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding IllusoryDiscountDetectionCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>
-                    <ui:Button Content="💬 AI Chat Assistant" HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                    <ui:Button Content="💬 AI Chat Assistant" AutomationProperties.Name="AI Chat Assistant" HorizontalAlignment="Stretch" Margin="0,0,0,6"
                            Command="{Binding ChatCommand}"
                            Appearance="Transparent"
                            Padding="8,6" Cursor="Hand" FontSize="13"/>

--- a/AdvGenPriceComparer.WPF/Views/BestPricesWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/BestPricesWindow.xaml
@@ -37,7 +37,7 @@
                 </StackPanel>
                 
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <Button Content="🔄 Refresh" Padding="15,8" Margin="0,0,10,0"
+                    <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh" Padding="15,8" Margin="0,0,10,0"
                             Command="{Binding RefreshCommand}"
                             Background="White" Foreground="{DynamicResource SystemAccentColorBrush}"/>
                 </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/CloudSyncStatusWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/CloudSyncStatusWindow.xaml
@@ -147,13 +147,13 @@
                         <!-- Quick Actions -->
                         <GroupBox Header="Quick Actions" Margin="0,15,0,0">
                             <WrapPanel Margin="10">
-                                <Button Content="🔄 Sync Now" Style="{StaticResource ActionButton}" 
+                                <Button Content="🔄 Sync Now" AutomationProperties.Name="Sync Now" Style="{StaticResource ActionButton}"
                                         Command="{Binding SyncNowCommand}" IsEnabled="{Binding CanSync}"/>
-                                <Button Content="📤 Export to Cloud" Style="{StaticResource ActionButton}" 
+                                <Button Content="📤 Export to Cloud" AutomationProperties.Name="Export to Cloud" Style="{StaticResource ActionButton}"
                                         Command="{Binding ExportCommand}" IsEnabled="{Binding CanSync}"/>
-                                <Button Content="📥 Import from Cloud" Style="{StaticResource ActionButton}" 
+                                <Button Content="📥 Import from Cloud" AutomationProperties.Name="Import from Cloud" Style="{StaticResource ActionButton}"
                                         Command="{Binding ImportCommand}" IsEnabled="{Binding CanSync}"/>
-                                <Button Content="🔌 Test Connection" Style="{StaticResource ActionButton}" 
+                                <Button Content="🔌 Test Connection" AutomationProperties.Name="Test Connection" Style="{StaticResource ActionButton}"
                                         Command="{Binding TestConnectionCommand}" IsEnabled="{Binding CanSync}"/>
                             </WrapPanel>
                         </GroupBox>

--- a/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
@@ -212,16 +212,16 @@
                     Orientation="Horizontal" 
                     HorizontalAlignment="Right"
                     Margin="0,15,0,0">
-            <Button Content="🔄 Refresh" 
+            <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh"
                     Command="{Binding RefreshCommand}"
                     Style="{StaticResource SecondaryButtonStyle}"/>
-            <Button Content="✓ Dismiss Selected" 
+            <Button Content="✓ Dismiss Selected" AutomationProperties.Name="Dismiss Selected"
                     Command="{Binding DismissDealCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="✓✓ Dismiss All" 
+            <Button Content="✓✓ Dismiss All" AutomationProperties.Name="Dismiss All"
                     Command="{Binding DismissAllCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="🗑 Clear Dismissed" 
+            <Button Content="🗑 Clear Dismissed" AutomationProperties.Name="Clear Dismissed"
                     Command="{Binding ClearDismissedCommand}"
                     Style="{StaticResource SecondaryButtonStyle}"/>
         </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/MLModelManagementWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/MLModelManagementWindow.xaml
@@ -195,7 +195,7 @@
                                       Margin="0,4,0,0"/>
                         </Grid>
 
-                        <Button Content="🔄 Reload Model"
+                        <Button Content="🔄 Reload Model" AutomationProperties.Name="Reload Model"
                                 Command="{Binding ReloadModelCommand}"
                                 Style="{StaticResource SecondaryButtonStyle}"
                                 IsEnabled="{Binding IsNotBusy}"/>
@@ -205,7 +205,7 @@
                 <!-- Training Actions -->
                 <GroupBox Header="Training" Style="{StaticResource CardStyle}">
                     <StackPanel>
-                        <Button Content="📊 Train from Database"
+                        <Button Content="📊 Train from Database" AutomationProperties.Name="Train from Database"
                                 Command="{Binding TrainFromDatabaseCommand}"
                                 Style="{StaticResource ActionButtonStyle}"
                                 IsEnabled="{Binding IsNotBusy}"/>
@@ -215,7 +215,7 @@
                                   TextWrapping="Wrap"
                                   Margin="0,-4,0,12"/>
 
-                        <Button Content="📁 Train from CSV"
+                        <Button Content="📁 Train from CSV" AutomationProperties.Name="Train from CSV"
                                 Command="{Binding TrainFromCsvCommand}"
                                 Style="{StaticResource SecondaryButtonStyle}"
                                 IsEnabled="{Binding IsNotBusy}"/>
@@ -224,7 +224,7 @@
                                   Foreground="#666"
                                   Margin="0,-4,0,12"/>
 
-                        <Button Content="🔄 Retrain Model"
+                        <Button Content="🔄 Retrain Model" AutomationProperties.Name="Retrain Model"
                                 Command="{Binding RetrainModelCommand}"
                                 Style="{StaticResource SecondaryButtonStyle}"
                                 IsEnabled="{Binding CanRetrain}"/>

--- a/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
@@ -136,7 +136,7 @@
                           SelectedItem="{Binding FilterStatus}"
                           Width="120"
                           VerticalAlignment="Center"/>
-                <Button Content="🔄 Refresh" 
+                <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh"
                         Command="{Binding RefreshCommand}" 
                         Padding="10,5"
                         Margin="10,0,0,0"/>
@@ -145,7 +145,7 @@
             <!-- Toolbar -->
             <ToolBarTray Grid.Row="1" Margin="0,0,0,10">
                 <ToolBar>
-                    <Button Content="✓ Acknowledge" 
+                    <Button Content="✓ Acknowledge" AutomationProperties.Name="Acknowledge"
                             Command="{Binding AcknowledgeAlertCommand}"
                             CommandParameter="{Binding SelectedAlert}"
                             Padding="10,5"/>
@@ -159,12 +159,12 @@
                             CommandParameter="{Binding SelectedAlert}"
                             Padding="10,5"/>
                     <Separator/>
-                    <Button Content="🗑 Delete" 
+                    <Button Content="🗑 Delete" AutomationProperties.Name="Delete"
                             Command="{Binding DeleteAlertCommand}"
                             CommandParameter="{Binding SelectedAlert}"
                             Padding="10,5"/>
                     <Separator/>
-                    <Button Content="🔄 Clear Form" 
+                    <Button Content="🔄 Clear Form" AutomationProperties.Name="Clear Form"
                             Command="{Binding ClearFormCommand}"
                             Padding="10,5"/>
                 </ToolBar>

--- a/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
@@ -93,12 +93,12 @@
             <!-- Toolbar -->
             <ToolBarTray Grid.Row="0" Margin="0,0,0,10">
                 <ToolBar>
-                    <Button Content="🔄 Refresh" Command="{Binding RefreshCommand}" Padding="10,5"/>
+                    <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh" Command="{Binding RefreshCommand}" Padding="10,5"/>
                     <Separator/>
-                    <Button Content="✓ Mark All Read" Command="{Binding MarkAsReadCommand}" Padding="10,5"/>
-                    <Button Content="🗑 Clear All" Command="{Binding ClearAllCommand}" Padding="10,5"/>
+                    <Button Content="✓ Mark All Read" AutomationProperties.Name="Mark All Read" Command="{Binding MarkAsReadCommand}" Padding="10,5"/>
+                    <Button Content="🗑 Clear All" AutomationProperties.Name="Clear All" Command="{Binding ClearAllCommand}" Padding="10,5"/>
                     <Separator/>
-                    <Button Content="✕ Close" Command="{Binding CloseCommand}" Padding="10,5" ToolTip="Close window (Esc)"/>
+                    <Button Content="✕ Close" AutomationProperties.Name="Close" Command="{Binding CloseCommand}" Padding="10,5" ToolTip="Close window (Esc)"/>
                 </ToolBar>
             </ToolBarTray>
 

--- a/AdvGenPriceComparer.WPF/Views/PriceHistoryPage.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceHistoryPage.xaml
@@ -216,7 +216,7 @@
                                   SelectedItem="{Binding SelectedComparisonStore}"
                                   DisplayMemberPath="Name"
                                   Margin="0,0,8,0"/>
-                        <Button Content="📊 View Chart"
+                        <Button Content="📊 View Chart" AutomationProperties.Name="View Chart"
                                 Command="{Binding ToggleChartViewCommand}"
                                 Padding="12,6"
                                 Background="Transparent"

--- a/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
@@ -73,7 +73,7 @@
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    Margin="0,0,0,15"/>
 
-                        <Button Content="📁 Select Image File" 
+                        <Button Content="📁 Select Image File" AutomationProperties.Name="Select Image File"
                                 Command="{Binding ScanFromFileCommand}"
                                 Padding="20,10"
                                 HorizontalAlignment="Left"
@@ -132,11 +132,11 @@
                                 <StackPanel Grid.Row="1" 
                                             Orientation="Horizontal" 
                                             Margin="0,10,0,0">
-                                    <Button Content="📋 Copy" 
+                                    <Button Content="📋 Copy" AutomationProperties.Name="Copy"
                                             Command="{Binding CopyBarcodeCommand}"
                                             Padding="15,5"
                                             Margin="0,0,10,0"/>
-                                    <Button Content="🗑️ Clear" 
+                                    <Button Content="🗑️ Clear" AutomationProperties.Name="Clear"
                                             Command="{Binding ClearScanCommand}"
                                             Padding="15,5"
                                             Style="{StaticResource DefaultButtonStyle}"/>
@@ -294,12 +294,12 @@
 
                         <!-- Action Buttons -->
                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                            <Button Content="⚙️ Generate" 
+                            <Button Content="⚙️ Generate" AutomationProperties.Name="Generate"
                                     Command="{Binding GenerateBarcodeCommand}"
                                     Padding="20,10"
                                     Margin="0,0,10,0"
                                     Style="{StaticResource AccentButtonStyle}"/>
-                            <Button Content="🗑️ Clear" 
+                            <Button Content="🗑️ Clear" AutomationProperties.Name="Clear"
                                     Command="{Binding ClearGenerateCommand}"
                                     Padding="20,10"
                                     Style="{StaticResource DefaultButtonStyle}"/>
@@ -334,7 +334,7 @@
                             </Grid>
                         </Border>
 
-                        <Button Content="💾 Save Barcode" 
+                        <Button Content="💾 Save Barcode" AutomationProperties.Name="Save Barcode"
                                 Command="{Binding SaveBarcodeCommand}"
                                 Padding="20,10"
                                 Margin="0,15,0,0"

--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -289,10 +289,10 @@
                 </Grid.ColumnDefinitions>
 
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
-                    <Button Content="🔄 Discover Peers" Padding="15,8" Margin="0,0,10,0"
+                    <Button Content="🔄 Discover Peers" AutomationProperties.Name="Discover Peers" Padding="15,8" Margin="0,0,10,0"
                             Command="{Binding DiscoverPeersCommand}"
                             IsEnabled="{Binding IsDiscovering, Converter={StaticResource InverseBooleanConverter}}"/>
-                    <Button Content="💓 Check All Health" Padding="15,8" Margin="0,0,10,0"
+                    <Button Content="💓 Check All Health" AutomationProperties.Name="Check All Health" Padding="15,8" Margin="0,0,10,0"
                             Command="{Binding CheckAllHealthCommand}"
                             IsEnabled="{Binding IsDiscovering, Converter={StaticResource InverseBooleanConverter}}"/>
                 </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/TripOptimizerWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/TripOptimizerWindow.xaml
@@ -67,7 +67,7 @@
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                    <Button Content="🔄 Refresh" 
+                    <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh"
                             Command="{Binding RefreshListsCommand}"
                             Padding="12,8" Margin="0,0,8,0"
                             Background="#FFFFFF" Foreground="#0D6EFD" BorderThickness="0"/>
@@ -434,11 +434,11 @@
                            VerticalAlignment="Center"/>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <Button Content="📋 Copy to Clipboard"
+                    <Button Content="📋 Copy to Clipboard" AutomationProperties.Name="Copy to Clipboard"
                             Command="{Binding ExportResultsCommand}"
                             Padding="12,8" Margin="0,0,8,0"
                             Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                    <Button Content="🖨️ Print"
+                    <Button Content="🖨️ Print" AutomationProperties.Name="Print"
                             Command="{Binding PrintResultsCommand}"
                             Padding="12,8"
                             Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}"/>

--- a/AdvGenPriceComparer.WPF/Views/WeeklySpecialsDigestWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/WeeklySpecialsDigestWindow.xaml
@@ -233,16 +233,16 @@
                     Orientation="Horizontal" 
                     HorizontalAlignment="Right"
                     Margin="0,15,0,0">
-            <Button Content="🔄 Refresh" 
+            <Button Content="🔄 Refresh" AutomationProperties.Name="Refresh"
                     Command="{Binding GenerateDigestCommand}"
                     Style="{StaticResource SecondaryButtonStyle}"/>
-            <Button Content="📋 Copy" 
+            <Button Content="📋 Copy" AutomationProperties.Name="Copy"
                     Command="{Binding CopyToClipboardCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="📝 Export Markdown" 
+            <Button Content="📝 Export Markdown" AutomationProperties.Name="Export Markdown"
                     Command="{Binding ExportMarkdownCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="📄 Export Text" 
+            <Button Content="📄 Export Text" AutomationProperties.Name="Export Text"
                     Command="{Binding ExportTextCommand}"
                     Style="{StaticResource ButtonStyle}"/>
         </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/WeeklySpecialsImportWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/WeeklySpecialsImportWindow.xaml
@@ -105,14 +105,14 @@
             <!-- Action Buttons -->
             <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" 
                         Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="🔍 Preview" 
+                <Button Content="🔍 Preview" AutomationProperties.Name="Preview"
                         Command="{Binding PreviewCommand}"
                         IsEnabled="{Binding CanPreview}"
                         Padding="20,8" 
                         Margin="0,0,10,0"
                         Background="{DynamicResource SystemAccentColorBrush}"
                         Foreground="White"/>
-                <Button Content="📥 Import" 
+                <Button Content="📥 Import" AutomationProperties.Name="Import"
                         Command="{Binding ImportCommand}"
                         IsEnabled="{Binding CanImport}"
                         Padding="20,8" 


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` attributes to icon-only and emoji-prefix buttons across the WPF application.
🎯 Why: Screen readers cannot properly interpret raw emoji characters used in `Content` attributes, causing poor accessibility for visually impaired users.
♿ Accessibility: The explicit `AutomationProperties.Name` attributes provide clean text representations for screen readers, improving keyboard navigation and application usability.

---
*PR created automatically by Jules for task [12031259487747342105](https://jules.google.com/task/12031259487747342105) started by @michaelleungadvgen*