### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing cryptographic verification of downloaded updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2026-04-15 - Missing Cryptographic Verification on Downloaded Updates
+**Vulnerability:** Update mechanism downloaded and executed executable files without cryptographic verification.
+**Learning:** In auto-updater scenarios, missing cryptographic verification creates a severe Time-of-Check to Time-of-Use (TOCTOU) vulnerability where man-in-the-middle attacks can replace downloaded executables.
+**Prevention:** Compute and verify cryptographic hashes (like SHA-256) entirely in memory directly on downloaded byte arrays *before* persisting the bytes to the local filesystem for execution.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -29,7 +29,7 @@ public interface IUpdateService
     /// </summary>
     /// <param name="downloadUrl">URL to the installer</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Security.Cryptography;
 using System.Windows;
 
 namespace AdvGenPriceComparer.WPF.Services;
@@ -166,10 +167,11 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
+            var downloadUrl = updateResult.DownloadUrl;
             _logger.LogInfo($"Starting download from: {downloadUrl}");
 
             // For MSI installers, we download to temp and execute
@@ -183,6 +185,28 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            // Cryptographic verification
+            if (!string.IsNullOrWhiteSpace(updateResult.FileHash) &&
+                !string.Equals(updateResult.FileHash, "placeholder", StringComparison.OrdinalIgnoreCase))
+            {
+                string expectedHash = updateResult.FileHash;
+                if (expectedHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
+                {
+                    expectedHash = expectedHash.Substring(7);
+                }
+
+                using var sha256 = SHA256.Create();
+                var hashBytes = sha256.ComputeHash(data);
+                string actualHash = Convert.ToHexString(hashBytes);
+
+                if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update download failed cryptographic verification. Expected: {expectedHash}, Actual: {actualHash}");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** The application's auto-update mechanism (`UpdateService.cs`) downloaded and executed installer files (MSI/EXE) without any cryptographic verification of the downloaded payload before executing it.

🎯 **Impact:** This creates a severe Time-of-Check to Time-of-Use (TOCTOU) vulnerability where a Man-in-the-Middle (MITM) attacker or compromised network could intercept the download and replace the legitimate installer with malware. The application would then blindly execute the malicious payload with elevated privileges (due to `UseShellExecute = true`).

🔧 **Fix:** 
- Refactored `DownloadUpdateAsync` to accept the full `UpdateCheckResult`.
- Added logic to compute the SHA-256 hash directly on the downloaded byte array in memory *before* writing it to disk.
- Compared the computed hash against the `FileHash` provided in the update manifest, safely handling `sha256:` prefixes and case-insensitivity.
- Implemented a secure fallback to bypass hash validation only if the `FileHash` is legitimately missing or explicitly set to `placeholder`, ensuring the update process does not break for unhashed legacy updates.
- Added a journal entry to `.jules/sentinel.md` documenting the learning.

✅ **Verification:**
- Built application with `EnableWindowsTargeting=true`.
- Verified tests run and pass.

---
*PR created automatically by Jules for task [7425074080929587530](https://jules.google.com/task/7425074080929587530) started by @michaelleungadvgen*