### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive CORS configuration

### DIFF
--- a/AdvGenPriceComparer.Server/Program.cs
+++ b/AdvGenPriceComparer.Server/Program.cs
@@ -41,9 +41,22 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("SignalRPolicy", policy =>
     {
-        policy.AllowAnyOrigin()
-              .AllowAnyHeader()
-              .AllowAnyMethod();
+        var allowedOrigins = builder.Configuration.GetSection("CorsSettings:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins)
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
+        else
+        {
+            policy.WithOrigins(Array.Empty<string>())
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
     });
 });
 

--- a/AdvGenPriceComparer.Server/appsettings.Development.json
+++ b/AdvGenPriceComparer.Server/appsettings.Development.json
@@ -5,6 +5,14 @@
       "Microsoft.AspNetCore": "Information"
     }
   },
+  "CorsSettings": {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "http://localhost:5000",
+      "http://localhost:5173",
+      "https://localhost:7173"
+    ]
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=AdvGenPriceComparer_dev.db"
   },

--- a/AdvGenPriceComparer.Server/appsettings.json
+++ b/AdvGenPriceComparer.Server/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "CorsSettings": {
+    "AllowedOrigins": []
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=AdvGenPriceComparer.db"
   },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Overly permissive CORS policy (`AllowAnyOrigin()`) was configured for the SignalR WebSocket support.
🎯 Impact: Allowing any origin could permit malicious third-party websites to connect to the SignalR hub, potentially reading sensitive price/deal data or sending unauthorized commands on behalf of users if cross-origin requests were made.
🔧 Fix: Replaced `AllowAnyOrigin()` with a configuration-driven approach reading from `CorsSettings:AllowedOrigins` in `appsettings.json`. Added `AllowCredentials()` safely since specific origins are now required. Added default safe local development origins to `appsettings.Development.json` and a secure default (empty) array to the main `appsettings.json`.
✅ Verification: Built the server successfully. The fallback behavior blocks all cross-origins if the configuration is missing or empty.

---
*PR created automatically by Jules for task [13091425822176193339](https://jules.google.com/task/13091425822176193339) started by @michaelleungadvgen*