### PR TITLE
🎨 Palette: Add ARIA label to clear search button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-04-17 - WPF Text-Icon Button Accessibility
+**Learning:** In WPF applications, standard `Button` elements that use text-based icons (like "✕", "🗑️") without accompanying text lack proper text representation for screen readers.
+**Action:** Always explicitly define `AutomationProperties.Name` on buttons using text-based icons to ensure they are fully accessible to screen readers.

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -48,6 +48,7 @@
                 
                 <Button Grid.Column="1"
                         Content="✕"
+                        AutomationProperties.Name="Clear search"
                         Command="{Binding ClearSearchCommand}"
                         Width="40"
                         Height="40"


### PR DESCRIPTION
💡 What
Added `AutomationProperties.Name` to the text-based icon-only "✕" button in `GlobalSearchWindow.xaml`.

🎯 Why
Screen readers cannot naturally deduce the meaning of symbols like "✕" used as icons. Without an explicit text label, this button was inaccessible or confusing for users relying on assistive technologies.

📸 Before/After
Before: Screen reader may read "times" or "cross" or just "button" without context.
After: Screen reader explicitly reads "Clear search".

♿ Accessibility
Improves screen reader accessibility by providing a clear, descriptive ARIA-equivalent text label for an interactive element that relies solely on visual semantics.

---
*PR created automatically by Jules for task [9486014719095120303](https://jules.google.com/task/9486014719095120303) started by @michaelleungadvgen*