### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive CORS configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Overly Permissive CORS Configuration
+**Vulnerability:** The SignalR CORS policy was configured with `AllowAnyOrigin()`, which allows any website to make cross-origin requests to the server, potentially leading to CSRF or unauthorized access if not properly secured.
+**Learning:** `AllowAnyOrigin()` is a significant security risk, especially when combined with APIs that manage sensitive data or require credentials. It is mutually exclusive with `AllowCredentials()` in ASP.NET Core.
+**Prevention:** Always use `WithOrigins()` to specify explicit, trusted origins in production environments. Configure allowed origins via appsettings.json to allow flexibility across environments without compromising the default secure posture.

--- a/AdvGenPriceComparer.Server/Program.cs
+++ b/AdvGenPriceComparer.Server/Program.cs
@@ -41,9 +41,14 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("SignalRPolicy", policy =>
     {
-        policy.AllowAnyOrigin()
-              .AllowAnyHeader()
-              .AllowAnyMethod();
+        var allowedOrigins = builder.Configuration.GetSection("CorsSettings:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins)
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
     });
 });
 

--- a/AdvGenPriceComparer.Server/appsettings.Development.json
+++ b/AdvGenPriceComparer.Server/appsettings.Development.json
@@ -12,5 +12,11 @@
     "RequireApiKey": false,
     "DefaultRateLimit": 1000,
     "RateLimitWindowMinutes": 60
+  },
+  "CorsSettings": {
+    "AllowedOrigins": [
+      "http://localhost:5000",
+      "https://localhost:5001"
+    ]
   }
 }

--- a/AdvGenPriceComparer.Server/appsettings.json
+++ b/AdvGenPriceComparer.Server/appsettings.json
@@ -13,5 +13,8 @@
     "RequireApiKey": true,
     "DefaultRateLimit": 100,
     "RateLimitWindowMinutes": 60
+  },
+  "CorsSettings": {
+    "AllowedOrigins": []
   }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The SignalR CORS policy was configured with `AllowAnyOrigin()`, allowing any website to make cross-origin requests to the server.
🎯 Impact: This could potentially lead to Cross-Site Request Forgery (CSRF) or unauthorized access if not properly secured, especially if combined with credentials.
🔧 Fix: Removed `AllowAnyOrigin()` and configured the policy to read allowed origins from the `CorsSettings:AllowedOrigins` array in `appsettings.json`, falling back to blocking requests by default.
✅ Verification: Ran `dotnet build` to ensure the project still compiles correctly.

---
*PR created automatically by Jules for task [17765096469232666872](https://jules.google.com/task/17765096469232666872) started by @michaelleungadvgen*