### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in auto-updater

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-03-01 - Missing Integrity Check on Auto-Update Installer
+**Vulnerability:** The application's auto-updater downloaded executable installers directly to a temporary directory and executed them without performing any cryptographic hash validation, opening a critical Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an MITM attacker could substitute a malicious binary.
+**Learning:** Even when pulling update manifests via HTTPS, binary payloads can be tampered with or redirected. Verifying checksums prevents execution of compromised payloads.
+**Prevention:** Always compute a cryptographic hash (e.g., SHA-256) of the downloaded byte array in-memory against a trusted manifest hash before writing to disk and executing.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -29,7 +29,7 @@ public interface IUpdateService
     /// </summary>
     /// <param name="downloadUrl">URL to the installer</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(string downloadUrl, string fileHash = "");
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,7 +167,7 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(string downloadUrl, string fileHash = "")
     {
         try
         {
@@ -183,6 +184,24 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            if (!string.IsNullOrWhiteSpace(fileHash) && fileHash != "placeholder")
+            {
+                var expectedHash = fileHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase)
+                    ? fileHash.Substring(7)
+                    : fileHash;
+
+                using var sha256 = SHA256.Create();
+                var hashBytes = sha256.ComputeHash(data);
+                var actualHash = Convert.ToHexString(hashBytes);
+
+                if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update hash mismatch. Expected: {expectedHash}, Actual: {actualHash}");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl, _updateResult.FileHash);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application's auto-updater downloaded executable installers directly to a temporary directory and executed them without performing any cryptographic hash validation, opening a critical Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an MITM attacker could substitute a malicious binary.
🎯 **Impact:** An attacker intercepting the unencrypted download or modifying the temporary file could execute arbitrary code on the user's system with the privileges of the application (or higher, since the installer requests UAC elevation).
🔧 **Fix:** Added in-memory cryptographic hash validation (SHA-256) to the downloaded update binary before writing to disk and executing. It gracefully handles the expected `sha256:` prefix from the manifest and includes a fallback to ensure backwards compatibility if the hash is not strictly enforced.
✅ **Verification:** Rebuilt the WPF application with `dotnet build -p:EnableWindowsTargeting=true`. Tested the patch against the `UpdateNotificationWindow` call site to ensure compilation succeeds.

---
*PR created automatically by Jules for task [3270698457246457584](https://jules.google.com/task/3270698457246457584) started by @michaelleungadvgen*