### PR TITLE
🎨 Palette: Add ARIA labels to emoji buttons for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-04-18 - WPF Emoji Button Accessibility
+**Learning:** Using emojis as button Content in WPF XAML does not automatically provide accessible names to screen readers, unlike standard text. Relying solely on `ToolTip` is insufficient.
+**Action:** Always explicitly define `AutomationProperties.Name` on icon-only and emoji buttons in WPF applications to provide clear, textual ARIA-equivalent labels.

--- a/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
@@ -119,7 +119,7 @@
                         BorderThickness="0"
                         Foreground="White"
                         FontSize="16"
-                        Click="CloseButton_Click"/>
+                        Click="CloseButton_Click" AutomationProperties.Name="Close"/>
             </Grid>
         </Border>
 
@@ -308,7 +308,7 @@
                         Background="Transparent"
                         BorderThickness="0"
                         ToolTip="Clear chat"
-                        Command="{Binding ClearChatCommand}"/>
+                        Command="{Binding ClearChatCommand}" AutomationProperties.Name="Delete"/>
 
                 <Button Grid.Column="2"
                         Content="➤"

--- a/AdvGenPriceComparer.WPF/Views/BestPricesWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/BestPricesWindow.xaml
@@ -39,7 +39,7 @@
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <Button Content="🔄 Refresh" Padding="15,8" Margin="0,0,10,0"
                             Command="{Binding RefreshCommand}"
-                            Background="White" Foreground="{DynamicResource SystemAccentColorBrush}"/>
+                            Background="White" Foreground="{DynamicResource SystemAccentColorBrush}" AutomationProperties.Name="Refresh"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/AdvGenPriceComparer.WPF/Views/CloudSyncStatusWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/CloudSyncStatusWindow.xaml
@@ -148,7 +148,7 @@
                         <GroupBox Header="Quick Actions" Margin="0,15,0,0">
                             <WrapPanel Margin="10">
                                 <Button Content="🔄 Sync Now" Style="{StaticResource ActionButton}" 
-                                        Command="{Binding SyncNowCommand}" IsEnabled="{Binding CanSync}"/>
+                                        Command="{Binding SyncNowCommand}" IsEnabled="{Binding CanSync}" AutomationProperties.Name="Sync Now"/>
                                 <Button Content="📤 Export to Cloud" Style="{StaticResource ActionButton}" 
                                         Command="{Binding ExportCommand}" IsEnabled="{Binding CanSync}"/>
                                 <Button Content="📥 Import from Cloud" Style="{StaticResource ActionButton}" 

--- a/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
@@ -214,7 +214,7 @@
                     Margin="0,15,0,0">
             <Button Content="🔄 Refresh" 
                     Command="{Binding RefreshCommand}"
-                    Style="{StaticResource SecondaryButtonStyle}"/>
+                    Style="{StaticResource SecondaryButtonStyle}" AutomationProperties.Name="Refresh"/>
             <Button Content="✓ Dismiss Selected" 
                     Command="{Binding DismissDealCommand}"
                     Style="{StaticResource ButtonStyle}"/>
@@ -223,7 +223,7 @@
                     Style="{StaticResource ButtonStyle}"/>
             <Button Content="🗑 Clear Dismissed" 
                     Command="{Binding ClearDismissedCommand}"
-                    Style="{StaticResource SecondaryButtonStyle}"/>
+                    Style="{StaticResource SecondaryButtonStyle}" AutomationProperties.Name="Clear Dismissed"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -56,7 +56,7 @@
                         BorderThickness="0"
                         FontSize="18"
                         VerticalAlignment="Top"
-                        Cursor="Hand"/>
+                        Cursor="Hand" AutomationProperties.Name="Close"/>
             </Grid>
         </Border>
 

--- a/AdvGenPriceComparer.WPF/Views/MLModelManagementWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/MLModelManagementWindow.xaml
@@ -198,7 +198,7 @@
                         <Button Content="🔄 Reload Model"
                                 Command="{Binding ReloadModelCommand}"
                                 Style="{StaticResource SecondaryButtonStyle}"
-                                IsEnabled="{Binding IsNotBusy}"/>
+                                IsEnabled="{Binding IsNotBusy}" AutomationProperties.Name="Reload Model"/>
                     </StackPanel>
                 </GroupBox>
 
@@ -227,7 +227,7 @@
                         <Button Content="🔄 Retrain Model"
                                 Command="{Binding RetrainModelCommand}"
                                 Style="{StaticResource SecondaryButtonStyle}"
-                                IsEnabled="{Binding CanRetrain}"/>
+                                IsEnabled="{Binding CanRetrain}" AutomationProperties.Name="Retrain Model"/>
                         <TextBlock Text="Improve model with recent categorizations"
                                   FontSize="11"
                                   Foreground="#666"

--- a/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
@@ -139,7 +139,7 @@
                 <Button Content="🔄 Refresh" 
                         Command="{Binding RefreshCommand}" 
                         Padding="10,5"
-                        Margin="10,0,0,0"/>
+                        Margin="10,0,0,0" AutomationProperties.Name="Refresh"/>
             </StackPanel>
 
             <!-- Toolbar -->
@@ -162,11 +162,11 @@
                     <Button Content="🗑 Delete" 
                             Command="{Binding DeleteAlertCommand}"
                             CommandParameter="{Binding SelectedAlert}"
-                            Padding="10,5"/>
+                            Padding="10,5" AutomationProperties.Name="Delete"/>
                     <Separator/>
                     <Button Content="🔄 Clear Form" 
                             Command="{Binding ClearFormCommand}"
-                            Padding="10,5"/>
+                            Padding="10,5" AutomationProperties.Name="Clear Form"/>
                 </ToolBar>
             </ToolBarTray>
 

--- a/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
@@ -93,12 +93,12 @@
             <!-- Toolbar -->
             <ToolBarTray Grid.Row="0" Margin="0,0,0,10">
                 <ToolBar>
-                    <Button Content="🔄 Refresh" Command="{Binding RefreshCommand}" Padding="10,5"/>
+                    <Button Content="🔄 Refresh" Command="{Binding RefreshCommand}" Padding="10,5" AutomationProperties.Name="Refresh"/>
                     <Separator/>
                     <Button Content="✓ Mark All Read" Command="{Binding MarkAsReadCommand}" Padding="10,5"/>
-                    <Button Content="🗑 Clear All" Command="{Binding ClearAllCommand}" Padding="10,5"/>
+                    <Button Content="🗑 Clear All" Command="{Binding ClearAllCommand}" Padding="10,5" AutomationProperties.Name="Clear All"/>
                     <Separator/>
-                    <Button Content="✕ Close" Command="{Binding CloseCommand}" Padding="10,5" ToolTip="Close window (Esc)"/>
+                    <Button Content="✕ Close" Command="{Binding CloseCommand}" Padding="10,5" ToolTip="Close window (Esc)" AutomationProperties.Name="Close"/>
                 </ToolBar>
             </ToolBarTray>
 

--- a/AdvGenPriceComparer.WPF/Views/PriceHistoryPage.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceHistoryPage.xaml
@@ -178,7 +178,7 @@
                             Foreground="#666"
                             BorderThickness="0"
                             Cursor="Hand"
-                            FontSize="13"/>
+                            FontSize="13" AutomationProperties.Name="Refresh"/>
                 </Grid>
             </Grid>
         </Border>

--- a/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
@@ -135,11 +135,11 @@
                                     <Button Content="📋 Copy" 
                                             Command="{Binding CopyBarcodeCommand}"
                                             Padding="15,5"
-                                            Margin="0,0,10,0"/>
+                                            Margin="0,0,10,0" AutomationProperties.Name="Copy"/>
                                     <Button Content="🗑️ Clear" 
                                             Command="{Binding ClearScanCommand}"
                                             Padding="15,5"
-                                            Style="{StaticResource DefaultButtonStyle}"/>
+                                            Style="{StaticResource DefaultButtonStyle}" AutomationProperties.Name="Clear"/>
                                 </StackPanel>
                             </Grid>
                         </GroupBox>
@@ -298,11 +298,11 @@
                                     Command="{Binding GenerateBarcodeCommand}"
                                     Padding="20,10"
                                     Margin="0,0,10,0"
-                                    Style="{StaticResource AccentButtonStyle}"/>
+                                    Style="{StaticResource AccentButtonStyle}" AutomationProperties.Name="Generate"/>
                             <Button Content="🗑️ Clear" 
                                     Command="{Binding ClearGenerateCommand}"
                                     Padding="20,10"
-                                    Style="{StaticResource DefaultButtonStyle}"/>
+                                    Style="{StaticResource DefaultButtonStyle}" AutomationProperties.Name="Clear"/>
                         </StackPanel>
                     </StackPanel>
 

--- a/AdvGenPriceComparer.WPF/Views/ShoppingListWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/ShoppingListWindow.xaml
@@ -190,7 +190,7 @@
                             Content="➕ Create"
                             Command="{Binding CreateListCommand}"
                             Style="{StaticResource ActionButtonStyle}"
-                            Margin="8,0,0,0"/>
+                            Margin="8,0,0,0" AutomationProperties.Name="Create"/>
                 </Grid>
 
                 <!-- Lists -->
@@ -328,7 +328,7 @@
                             Content="➕ Add"
                             Command="{Binding AddItemCommand}"
                             Style="{StaticResource ActionButtonStyle}"
-                            Margin="8,0,0,0"/>
+                            Margin="8,0,0,0" AutomationProperties.Name="Add"/>
                 </Grid>
 
                 <!-- Items List -->

--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -291,7 +291,7 @@
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
                     <Button Content="🔄 Discover Peers" Padding="15,8" Margin="0,0,10,0"
                             Command="{Binding DiscoverPeersCommand}"
-                            IsEnabled="{Binding IsDiscovering, Converter={StaticResource InverseBooleanConverter}}"/>
+                            IsEnabled="{Binding IsDiscovering, Converter={StaticResource InverseBooleanConverter}}" AutomationProperties.Name="Discover Peers"/>
                     <Button Content="💓 Check All Health" Padding="15,8" Margin="0,0,10,0"
                             Command="{Binding CheckAllHealthCommand}"
                             IsEnabled="{Binding IsDiscovering, Converter={StaticResource InverseBooleanConverter}}"/>

--- a/AdvGenPriceComparer.WPF/Views/TripOptimizerWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/TripOptimizerWindow.xaml
@@ -70,7 +70,7 @@
                     <Button Content="🔄 Refresh" 
                             Command="{Binding RefreshListsCommand}"
                             Padding="12,8" Margin="0,0,8,0"
-                            Background="#FFFFFF" Foreground="#0D6EFD" BorderThickness="0"/>
+                            Background="#FFFFFF" Foreground="#0D6EFD" BorderThickness="0" AutomationProperties.Name="Refresh"/>
                 </StackPanel>
             </Grid>
         </Border>
@@ -437,11 +437,11 @@
                     <Button Content="📋 Copy to Clipboard"
                             Command="{Binding ExportResultsCommand}"
                             Padding="12,8" Margin="0,0,8,0"
-                            Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                            Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}" AutomationProperties.Name="Copy to Clipboard"/>
                     <Button Content="🖨️ Print"
                             Command="{Binding PrintResultsCommand}"
                             Padding="12,8"
-                            Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                            Visibility="{Binding HasResults, Converter={StaticResource BooleanToVisibilityConverter}}" AutomationProperties.Name="Print"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/AdvGenPriceComparer.WPF/Views/WeeklySpecialsDigestWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/WeeklySpecialsDigestWindow.xaml
@@ -235,10 +235,10 @@
                     Margin="0,15,0,0">
             <Button Content="🔄 Refresh" 
                     Command="{Binding GenerateDigestCommand}"
-                    Style="{StaticResource SecondaryButtonStyle}"/>
+                    Style="{StaticResource SecondaryButtonStyle}" AutomationProperties.Name="Refresh"/>
             <Button Content="📋 Copy" 
                     Command="{Binding CopyToClipboardCommand}"
-                    Style="{StaticResource ButtonStyle}"/>
+                    Style="{StaticResource ButtonStyle}" AutomationProperties.Name="Copy"/>
             <Button Content="📝 Export Markdown" 
                     Command="{Binding ExportMarkdownCommand}"
                     Style="{StaticResource ButtonStyle}"/>


### PR DESCRIPTION
💡 **What:** Added `AutomationProperties.Name` to various `ui:Button` elements in the WPF project that relied solely on emojis (e.g., 🔄, 🗑️, ➕) for their visual representation in the `Content` property. 

🎯 **Why:** Screen readers in WPF do not automatically translate visual emojis into clear, contextual actions, often reading out literal Unicode descriptions like "Clockwise vertical arrows" instead of the intended "Refresh". Relying on `ToolTip` is insufficient for assistive technology. This enhancement ensures all users understand the purpose of these icon-only buttons.

📸 **Before/After:** No visual changes were made.

♿ **Accessibility:** This directly improves screen reader accessibility by providing an ARIA-equivalent explicit text label to previously non-semantic visual buttons, enabling clear navigation for visually impaired users.

---
*PR created automatically by Jules for task [1550871577453138504](https://jules.google.com/task/1550871577453138504) started by @michaelleungadvgen*