### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive CORS policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-05-18 - Overly Permissive CORS Policy
+**Vulnerability:** The SignalR setup in `AdvGenPriceComparer.Server` used `.AllowAnyOrigin()`, which accepts connections from any domain, along with WebSockets making it vulnerable to CSWSH and other cross-origin data exposure.
+**Learning:** SignalR endpoints shouldn't allow any origin while accepting credentials (although mutually exclusive usually, .AllowCredentials() could be added, restricting `AllowAnyOrigin`). A static list of explicitly trusted origins from configuration prevents unwanted cross-origin clients.
+**Prevention:** Always restrict CORS policies to explicitly allowed domains by loading them from configuration rather than using `.AllowAnyOrigin()`, and only pair it with `.AllowCredentials()` when explicitly listed origins are provided.

--- a/AdvGenPriceComparer.Server/Program.cs
+++ b/AdvGenPriceComparer.Server/Program.cs
@@ -41,9 +41,22 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("SignalRPolicy", policy =>
     {
-        policy.AllowAnyOrigin()
-              .AllowAnyHeader()
-              .AllowAnyMethod();
+        var allowedOrigins = builder.Configuration.GetSection("CorsSettings:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins)
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
+        else
+        {
+            // Secure fallback
+            policy.WithOrigins("https://localhost:none")
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
     });
 });
 

--- a/AdvGenPriceComparer.Server/appsettings.Development.json
+++ b/AdvGenPriceComparer.Server/appsettings.Development.json
@@ -12,5 +12,8 @@
     "RequireApiKey": false,
     "DefaultRateLimit": 1000,
     "RateLimitWindowMinutes": 60
+  },
+  "CorsSettings": {
+    "AllowedOrigins": ["http://localhost:5000", "https://localhost:5001", "http://localhost:3000", "http://localhost:8080", "http://localhost:5173", "http://localhost:4200"]
   }
 }

--- a/AdvGenPriceComparer.Server/appsettings.json
+++ b/AdvGenPriceComparer.Server/appsettings.json
@@ -13,5 +13,8 @@
     "RequireApiKey": true,
     "DefaultRateLimit": 100,
     "RateLimitWindowMinutes": 60
+  },
+  "CorsSettings": {
+    "AllowedOrigins": ["http://localhost:5000", "https://localhost:5001", "http://localhost:3000"]
   }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The SignalR endpoint in `Program.cs` had a very permissive CORS policy, allowing any origin (`AllowAnyOrigin()`) which risks CSRF/CSWSH attacks and data exposure when dealing with APIs.
🎯 Impact: Attackers could potentially connect to the WebSocket hub from a malicious website or make cross-origin requests to read/write data on behalf of an authenticated user.
🔧 Fix: Updated the CORS setup to read explicitly allowed origins from `appsettings.json` and `appsettings.Development.json` using `WithOrigins()` combined with `AllowCredentials()`. A secure fallback explicitly blocks origins if no valid origins exist.
✅ Verification: Ensure the server builds and existing endpoints/websockets correctly reject requests originating from unlisted domains.

---
*PR created automatically by Jules for task [7514725339343602260](https://jules.google.com/task/7514725339343602260) started by @michaelleungadvgen*