### PR TITLE
🎨 Palette: Add accessible name to favorite button

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" AutomationProperties.Name="Toggle Favorite" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
💡 **What:** Added `AutomationProperties.Name="Toggle Favorite"` to the icon-only "★" toggle favorite button in `AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml`.

🎯 **Why:** To ensure the button is properly announced by screen readers. A button that just contains the "★" text character does not inherently convey its purpose to assistive technologies.

♿ **Accessibility:**
- Added `AutomationProperties.Name` equivalent to `aria-label` to provide an accessible, descriptive text node for the element.

---
*PR created automatically by Jules for task [8528525433064787260](https://jules.google.com/task/8528525433064787260) started by @michaelleungadvgen*