### PR TITLE
🎨 Palette: Add screen reader accessibility labels to icon-only buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
@@ -113,6 +113,7 @@
 
                 <Button Grid.Column="1" 
                         Content="✕" 
+                        AutomationProperties.Name="Close"
                         Width="30" 
                         Height="30"
                         Background="Transparent"
@@ -305,6 +306,7 @@
                         Width="40"
                         Height="40"
                         Margin="10,0"
+                        AutomationProperties.Name="Clear chat"
                         Background="Transparent"
                         BorderThickness="0"
                         ToolTip="Clear chat"
@@ -315,6 +317,7 @@
                         FontSize="16"
                         Width="45"
                         Height="45"
+                        AutomationProperties.Name="Send message"
                         Background="#0078D4"
                         Foreground="White"
                         BorderThickness="0"

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -49,6 +49,7 @@
                 <Button Grid.Column="1"
                         Content="✕"
                         Command="{Binding ClearSearchCommand}"
+                        AutomationProperties.Name="Clear search"
                         Width="40"
                         Height="40"
                         Background="Transparent"


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` attributes to several icon-only standard and custom buttons.
🎯 Why: In WPF, relying solely on text-based icons (like "✕", "🗑️") or tooltip attributes does not properly expose the control to screen readers. Defining an AutomationProperties.Name acts identically to an `aria-label` in web contexts, allowing assistive technologies to audibly state the button's action.
📸 Before/After: Visual presentation remains exactly identical, but accessibility tree mapping is now properly generated.
♿ Accessibility: Ensures that generic actions (such as clear, delete, or send) in chat views and global search views are effectively understandable when using screen readers.

---
*PR created automatically by Jules for task [1738368105338692159](https://jules.google.com/task/1738368105338692159) started by @michaelleungadvgen*