### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified executable downloads in auto-update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-03-05 - Unverified Executable Downloads in Auto-Update
+**Vulnerability:** The WPF auto-update mechanism downloaded executables (MSI/EXE) via HTTP(S) and immediately executed them via `Process.Start` without cryptographically verifying their integrity, exposing users to RCE risks via compromised servers or hijacked URLs.
+**Learning:** Even when using HTTPS and having file hashes available in an update manifest, failing to enforce hash verification before writing the file to disk or executing it negates those security controls.
+**Prevention:** Always verify downloaded executables against a trusted hash (e.g., SHA-256) in memory before saving to the file system and executing. Handle hash mismatches by securely failing the operation.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -28,8 +28,9 @@ public interface IUpdateService
     /// Download and install the update (if silent update is supported)
     /// </summary>
     /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="expectedHash">Expected SHA-256 hash of the downloaded file</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(string downloadUrl, string expectedHash = "");
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
@@ -166,7 +167,7 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(string downloadUrl, string expectedHash = "")
     {
         try
         {
@@ -183,6 +184,25 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            if (!string.IsNullOrWhiteSpace(expectedHash))
+            {
+                string cleanExpectedHash = expectedHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase)
+                    ? expectedHash.Substring(7)
+                    : expectedHash;
+
+                // Valid placeholder fallback gracefully allows execution
+                if (!cleanExpectedHash.Equals("placeholder_replace_with_actual_hash", StringComparison.OrdinalIgnoreCase))
+                {
+                    var hashBytes = SHA256.HashData(data);
+                    if (!string.Equals(Convert.ToHexString(hashBytes), cleanExpectedHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogError($"Update file hash mismatch. Expected: {cleanExpectedHash}, Actual: {Convert.ToHexString(hashBytes)}");
+                        return false;
+                    }
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl, _updateResult.FileHash);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The WPF auto-update mechanism downloaded executables (MSI/EXE) via HTTP(S) and executed them immediately via `Process.Start` without cryptographically verifying their integrity against the manifest, risking Remote Code Execution (RCE) via compromised servers or MITM attacks.
🎯 **Impact:** An attacker who compromises the update download server or hijacks the URL could serve malicious executables, which the application would blindly execute with user privileges (or elevated privileges for MSIs).
🔧 **Fix:** 
- Updated `IUpdateService.cs` and `UpdateService.cs` to accept an `expectedHash` parameter in `DownloadUpdateAsync`.
- Implemented in-memory SHA-256 hash computation of the downloaded bytes.
- Added strict case-insensitive hash comparison before writing the file to disk or executing it.
- Gracefully handles missing/placeholder hashes to avoid breaking current update flows while enabling strict enforcement where hashes are provided.
✅ **Verification:** Compiled WPF project targeting `.NET 10.0 WindowsDesktop` using `dotnet build AdvGenPriceComparer.WPF/AdvGenPriceComparer.WPF.csproj -p:EnableWindowsTargeting=true`. Reviewed the logic for handling placeholder hashes.

---
*PR created automatically by Jules for task [5324860520985720260](https://jules.google.com/task/5324860520985720260) started by @michaelleungadvgen*