### PR TITLE
🎨 Palette: Add AutomationProperties.Name to icon-only buttons for accessibility

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -49,6 +49,7 @@
                 <Button Grid.Column="1"
                         Content="✕"
                         Command="{Binding ClearSearchCommand}"
+                        AutomationProperties.Name="Clear search"
                         Width="40"
                         Height="40"
                         Background="Transparent"

--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}" AutomationProperties.Name="Toggle favorite"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
## 💡 What
Added `AutomationProperties.Name` to two icon-only buttons in the WPF application:
1. The "✕" clear search button in `GlobalSearchWindow.xaml`.
2. The "★" toggle favorite button in `StaticPeerConfigWindow.xaml`.

## 🎯 Why
These buttons relied entirely on text symbols ("✕" and "★") without any textual equivalent. Screen readers would either announce these literally (e.g., "star symbol") or ignore them entirely, making it impossible for visually impaired users to understand their function.

## ♿ Accessibility
This change ensures that screen readers will correctly announce "Clear search" and "Toggle favorite" when these buttons are focused, making the interface significantly more accessible for keyboard and screen reader users without altering the visual design.

---
*PR created automatically by Jules for task [14912854573070712669](https://jules.google.com/task/14912854573070712669) started by @michaelleungadvgen*