### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix auto-update payload hash verification bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-03-01 - Missing Hash Verification in Auto-Update Mechanism
+**Vulnerability:** The auto-update mechanism downloaded an executable/MSI payload and executed it without verifying its integrity against the provided SHA-256 hash.
+**Learning:** Even when pulling update manifests via HTTPS, omitting cryptographic signature or hash verification on the downloaded payload exposes the application to supply-chain attacks, leading to unauthenticated arbitrary code execution.
+**Prevention:** Always cryptographically verify downloaded executable payloads in memory before writing to disk and executing. Fallbacks should exist for graceful failures but hashes must be enforced when present.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -28,8 +28,9 @@ public interface IUpdateService
     /// Download and install the update (if silent update is supported)
     /// </summary>
     /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="expectedHash">Expected hash of the file</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(string downloadUrl, string expectedHash = "");
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -166,7 +166,7 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(string downloadUrl, string expectedHash = "")
     {
         try
         {
@@ -183,6 +183,24 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            if (!string.IsNullOrWhiteSpace(expectedHash) && !expectedHash.Equals("placeholder", StringComparison.OrdinalIgnoreCase))
+            {
+                string cleanHash = expectedHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase)
+                    ? expectedHash.Substring(7)
+                    : expectedHash;
+
+                using var sha256 = System.Security.Cryptography.SHA256.Create();
+                var hashBytes = sha256.ComputeHash(data);
+                var actualHash = Convert.ToHexString(hashBytes);
+
+                if (!string.Equals(actualHash, cleanHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update hash mismatch! Expected: {cleanHash}, Actual: {actualHash}");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl, _updateResult.FileHash);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The auto-update mechanism downloaded new `.msi` or `.exe` payloads from the URL provided in `updates.json` and executed them immediately without validating their cryptographic signature against the `FileHash`.
🎯 **Impact:** If the HTTPS connection was compromised (MITM) or the storage bucket was hijacked, an attacker could substitute the legitimate installer with arbitrary malware, resulting in unauthenticated remote code execution with the user's privileges.
🔧 **Fix:** 
- Updated `IUpdateService` and `UpdateService` to accept the expected `FileHash` during `DownloadUpdateAsync`.
- Implemented SHA-256 calculation on the downloaded byte array in memory *before* writing to disk.
- Automatically strips `sha256:` prefixes when comparing hashes.
- Discards the file and aborts execution if the hash does not match, logging the attempt.
- Gracefully handles missing/placeholder hashes.
- Updated `UpdateNotificationWindow` to pass the hash to the service.
✅ **Verification:** Compiled the application cleanly using `dotnet build -p:EnableWindowsTargeting=true`. Tested hash calculation via isolated script. Reviewed log to ensure hashes are accurately evaluated.

---
*PR created automatically by Jules for task [1579598408505792956](https://jules.google.com/task/1579598408505792956) started by @michaelleungadvgen*