### PR TITLE
🛡️ Sentinel: [HIGH] Fix Overly Permissive CORS Configuration

### DIFF
--- a/AdvGenPriceComparer.Server/Program.cs
+++ b/AdvGenPriceComparer.Server/Program.cs
@@ -41,9 +41,14 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("SignalRPolicy", policy =>
     {
-        policy.AllowAnyOrigin()
-              .AllowAnyHeader()
-              .AllowAnyMethod();
+        var allowedOrigins = builder.Configuration.GetSection("CorsSettings:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins)
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
     });
 });
 

--- a/AdvGenPriceComparer.Server/appsettings.json
+++ b/AdvGenPriceComparer.Server/appsettings.json
@@ -13,5 +13,8 @@
     "RequireApiKey": true,
     "DefaultRateLimit": 100,
     "RateLimitWindowMinutes": 60
+  },
+  "CorsSettings": {
+    "AllowedOrigins": []
   }
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was using an overly permissive CORS configuration (`AllowAnyOrigin()`) on the `SignalRPolicy`, allowing any domain to interact with the backend SignalR hub.
🎯 **Impact:** If exploited, a malicious website could bypass the same-origin policy, allowing it to perform unauthorized cross-origin requests, potentially intercepting real-time WebSocket communication or sending forged price updates on behalf of an authenticated user.
🔧 **Fix:** Replaced `AllowAnyOrigin()` with a configuration-driven approach. The CORS policy now explicitly allows only the origins specified in `appsettings.json` under `CorsSettings:AllowedOrigins`. Additionally, it adds `AllowCredentials()` which is necessary for SignalR but requires `AllowAnyOrigin` to be removed.
✅ **Verification:** Ran `dotnet build` successfully. Reviewed the diffs to ensure the CORS policy strictly relies on the configuration array and that the `appsettings.json` defaults to an empty, secure list.

---
*PR created automatically by Jules for task [7447632024492410548](https://jules.google.com/task/7447632024492410548) started by @michaelleungadvgen*