### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix update verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-10-25 - Missing Cryptographic Hash Verification on Auto-Updates
+**Vulnerability:** The auto-update mechanism downloaded and executed MSI installers without verifying their cryptographic signatures, allowing potential execution of tampered payloads.
+**Learning:** Checking auto-update file hashes must be performed in memory before writing to disk to prevent Time-of-Check to Time-of-Use (TOCTOU) exploits where the file could be replaced between validation and execution.
+**Prevention:** Always compute hashes on the downloaded byte arrays in memory and verify them against expected values provided in the secure update manifest before writing to the local filesystem.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -27,9 +27,9 @@ public interface IUpdateService
     /// <summary>
     /// Download and install the update (if silent update is supported)
     /// </summary>
-    /// <param name="downloadUrl">URL to the installer</param>
+    /// <param name="updateResult">Update check result</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult);
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -166,16 +166,16 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(UpdateCheckResult updateResult)
     {
         try
         {
-            _logger.LogInfo($"Starting download from: {downloadUrl}");
+            _logger.LogInfo($"Starting download from: {updateResult.DownloadUrl}");
 
             // For MSI installers, we download to temp and execute
             var tempPath = Path.Combine(Path.GetTempPath(), "AdvGenPriceComparer_Update.msi");
 
-            var response = await _httpClient.GetAsync(downloadUrl);
+            var response = await _httpClient.GetAsync(updateResult.DownloadUrl);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to download update: HTTP {(int)response.StatusCode}");
@@ -183,6 +183,25 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            // Verify file hash if provided
+            if (!string.IsNullOrEmpty(updateResult.FileHash) && !updateResult.FileHash.Contains("placeholder", StringComparison.OrdinalIgnoreCase))
+            {
+                var expectedHash = updateResult.FileHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase)
+                    ? updateResult.FileHash.Substring(7)
+                    : updateResult.FileHash;
+
+                using var sha256 = System.Security.Cryptography.SHA256.Create();
+                var hashBytes = sha256.ComputeHash(data);
+                var actualHash = Convert.ToHexString(hashBytes);
+
+                if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update file hash validation failed. Expected: {expectedHash}, Actual: {actualHash}");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: The auto-update mechanism downloaded and executed MSI installers without verifying their cryptographic signatures. A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed where a malicious actor could intercept and replace the downloaded file before execution.

🎯 **Impact**: Potential arbitrary code execution with elevated privileges if an attacker tampered with the auto-update download.

🔧 **Fix**: Refactored `DownloadUpdateAsync` in `UpdateService.cs` to accept the `UpdateCheckResult` object. Implemented SHA256 verification on the byte array in memory *before* writing the installer to the local disk. Gracefully handles missing/placeholder hashes.

✅ **Verification**:
- `dotnet build AdvGenPriceComparer.WPF/AdvGenPriceComparer.WPF.csproj -p:EnableWindowsTargeting=true` succeeds.
- Replaced `_updateResult.DownloadUrl` with `_updateResult` across `UpdateService`, `IUpdateService`, and `UpdateNotificationWindow`.

---
*PR created automatically by Jules for task [7669801726458849587](https://jules.google.com/task/7669801726458849587) started by @michaelleungadvgen*