### PR TITLE
🎨 Palette: Add AutomationProperties.Name to icon-only buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
@@ -308,6 +308,7 @@
                         Background="Transparent"
                         BorderThickness="0"
                         ToolTip="Clear chat"
+                        AutomationProperties.Name="Clear chat"
                         Command="{Binding ClearChatCommand}"/>
 
                 <Button Grid.Column="2"

--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}" AutomationProperties.Name="Toggle favorite"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` to two icon-only buttons in the WPF application (`PriceChatWindow.xaml` and `StaticPeerConfigWindow.xaml`) to provide descriptive text labels.
🎯 Why: Icon-only buttons lacking text or descriptive attributes are completely inaccessible to screen readers, leaving visually impaired users unable to determine the button's purpose.
📸 Before/After: Visuals are unchanged. The buttons still display their respective icons ("🗑️" and "★").
♿ Accessibility: `AutomationProperties.Name` serves as an ARIA-label equivalent in WPF. Screen readers will now announce "Clear chat" and "Toggle favorite" respectively, instead of skipping the button or announcing unhelpful unicode character names.

---
*PR created automatically by Jules for task [4096009148964159541](https://jules.google.com/task/4096009148964159541) started by @michaelleungadvgen*