### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unverified binary execution in auto-updater

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** API keys were being written to local JSON files (`settings.json`) in plaintext by the `SettingsService`, making them accessible to any user or application with file system read access.
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-05-18 - Execution of Unverified Binaries in Auto-Updater
+**Vulnerability:** The application downloaded and immediately executed MSI/EXE files via `Process.Start` without cryptographically verifying the file's integrity against the provided manifest hash. This could allow execution of tampered binaries if the download server was compromised or traffic was intercepted.
+**Learning:** Checking response status codes during downloads is insufficient for security; downloaded executables must always have their integrity validated before writing to disk.
+**Prevention:** Compute the cryptographic hash (e.g., SHA-256) of the downloaded byte array in memory and verify it matches the expected hash from a trusted source before writing the bytes to the filesystem to prevent Time-of-Check to Time-of-Use (TOCTOU) vulnerabilities.

--- a/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/IUpdateService.cs
@@ -29,7 +29,7 @@ public interface IUpdateService
     /// </summary>
     /// <param name="downloadUrl">URL to the installer</param>
     /// <returns>True if download started successfully</returns>
-    Task<bool> DownloadUpdateAsync(string downloadUrl);
+    Task<bool> DownloadUpdateAsync(string downloadUrl, string expectedHash = "");
 
     /// <summary>
     /// Open the download page in browser

--- a/AdvGenPriceComparer.WPF/Services/UpdateService.cs
+++ b/AdvGenPriceComparer.WPF/Services/UpdateService.cs
@@ -166,7 +166,7 @@ public class UpdateService : IUpdateService
     }
 
     /// <inheritdoc />
-    public async Task<bool> DownloadUpdateAsync(string downloadUrl)
+    public async Task<bool> DownloadUpdateAsync(string downloadUrl, string expectedHash = "")
     {
         try
         {
@@ -183,6 +183,25 @@ public class UpdateService : IUpdateService
             }
 
             var data = await response.Content.ReadAsByteArrayAsync();
+
+            // Hash validation to prevent execution of unverified binaries (prevent TOCTOU)
+            if (!string.IsNullOrWhiteSpace(expectedHash) && !expectedHash.Contains("placeholder", StringComparison.OrdinalIgnoreCase))
+            {
+                var cleanExpectedHash = expectedHash.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase)
+                    ? expectedHash.Substring(7)
+                    : expectedHash;
+
+                using var sha256 = System.Security.Cryptography.SHA256.Create();
+                var actualHashBytes = sha256.ComputeHash(data);
+                var actualHash = Convert.ToHexString(actualHashBytes);
+
+                if (!string.Equals(actualHash, cleanExpectedHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError($"Update file hash mismatch! Expected: {cleanExpectedHash}, Actual: {actualHash}. Aborting installation.");
+                    return false;
+                }
+            }
+
             await File.WriteAllBytesAsync(tempPath, data);
 
             _logger.LogInfo($"Download completed: {tempPath}");

--- a/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
+++ b/AdvGenPriceComparer.WPF/Views/UpdateNotificationWindow.xaml.cs
@@ -118,7 +118,7 @@ public partial class UpdateNotificationWindow : Window
                     _updateResult.DownloadUrl.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                 {
                     // Try to download directly
-                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl);
+                    _ = _updateService.DownloadUpdateAsync(_updateResult.DownloadUrl, _updateResult.FileHash);
                 }
                 else
                 {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application downloaded and immediately executed MSI/EXE update files via `Process.Start` without cryptographically verifying the file's integrity against the provided manifest hash.
🎯 Impact: If the download server was compromised, or traffic intercepted (man-in-the-middle), tampered binaries could be executed, leading to arbitrary code execution on the user's machine.
🔧 Fix: Added cryptographic hash validation (SHA-256) of the downloaded byte array in memory before writing to disk, preventing Time-of-Check to Time-of-Use (TOCTOU) vulnerabilities. It falls back gracefully if the hash is missing or a placeholder.
✅ Verification: Run `dotnet build AdvGenPriceComparer.WPF/AdvGenPriceComparer.WPF.csproj -p:EnableWindowsTargeting=true` to verify it compiles. Review code changes in `UpdateService.cs`.

---
*PR created automatically by Jules for task [16891223517455858326](https://jules.google.com/task/16891223517455858326) started by @michaelleungadvgen*