### PR TITLE
🎨 Palette: Improve screen reader accessibility for emoji-prefixed buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-03-24 - Missing ARIA Labels on Emoji Buttons
+**Learning:** Standard WPF Button components that use emojis as visual icons in their `Content` property (e.g., `<Button Content="🗑️ Clear"/>` or `<Button Content="📁 Select Image File"/>`) without providing `AutomationProperties.Name` result in screen readers reading out the literal Unicode description of the emoji, causing a confusing user experience.
+**Action:** When using emojis or text-based symbols as icons inside standard WPF `Button` elements, always define a clean, text-only `AutomationProperties.Name` attribute to provide a proper ARIA-equivalent accessible name.

--- a/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
@@ -74,6 +74,7 @@
                                    Margin="0,0,0,15"/>
 
                         <Button Content="📁 Select Image File" 
+                                AutomationProperties.Name="Select Image File"
                                 Command="{Binding ScanFromFileCommand}"
                                 Padding="20,10"
                                 HorizontalAlignment="Left"
@@ -133,10 +134,12 @@
                                             Orientation="Horizontal" 
                                             Margin="0,10,0,0">
                                     <Button Content="📋 Copy" 
+                                            AutomationProperties.Name="Copy"
                                             Command="{Binding CopyBarcodeCommand}"
                                             Padding="15,5"
                                             Margin="0,0,10,0"/>
                                     <Button Content="🗑️ Clear" 
+                                            AutomationProperties.Name="Clear"
                                             Command="{Binding ClearScanCommand}"
                                             Padding="15,5"
                                             Style="{StaticResource DefaultButtonStyle}"/>
@@ -295,11 +298,13 @@
                         <!-- Action Buttons -->
                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                             <Button Content="⚙️ Generate" 
+                                    AutomationProperties.Name="Generate"
                                     Command="{Binding GenerateBarcodeCommand}"
                                     Padding="20,10"
                                     Margin="0,0,10,0"
                                     Style="{StaticResource AccentButtonStyle}"/>
                             <Button Content="🗑️ Clear" 
+                                    AutomationProperties.Name="Clear"
                                     Command="{Binding ClearGenerateCommand}"
                                     Padding="20,10"
                                     Style="{StaticResource DefaultButtonStyle}"/>
@@ -335,6 +340,7 @@
                         </Border>
 
                         <Button Content="💾 Save Barcode" 
+                                AutomationProperties.Name="Save Barcode"
                                 Command="{Binding SaveBarcodeCommand}"
                                 Padding="20,10"
                                 Margin="0,15,0,0"


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` attributes to standard WPF `Button` elements in `ScanBarcodeWindow.xaml` that use emojis as icons.

🎯 Why: To prevent screen readers from reading out the literal Unicode description of the emojis (e.g., "File folder, Select Image File" instead of just "Select Image File"), resulting in a clearer and more intuitive experience for users relying on assistive technologies.

📸 Before/After: 
- Before: `<Button Content="📁 Select Image File"/>` (Screen reader reads: "File folder, Select Image File")
- After: `<Button Content="📁 Select Image File" AutomationProperties.Name="Select Image File"/>` (Screen reader reads: "Select Image File")

♿ Accessibility: Significantly improves keyboard and screen reader accessibility by ensuring controls have accurate, concise ARIA-equivalent text names, complying with WCAG standards for non-text content and operable controls.

---
*PR created automatically by Jules for task [2355699337223588876](https://jules.google.com/task/2355699337223588876) started by @michaelleungadvgen*