### PR TITLE
🎨 Palette: Add ARIA-equivalent labels to emoji buttons for screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2023-10-27 - ARIA-equivalent labels for emoji buttons in WPF
+**Learning:** WPF `Button` elements that use text-based icons or emojis in their `Content` property (e.g., `Content="🗑️ Clear"`, `Content="✕"`) are read literally by screen readers, which can result in confusing announcements like "wastebasket clear button". Relying solely on `ToolTip` is insufficient for accessibility.
+**Action:** When standard `Button` elements in WPF use text-based icons or emojis, either alone or alongside text, explicitly define a text-only `AutomationProperties.Name` to ensure correct screen reader representation and prevent literal emoji announcements.

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -48,6 +48,7 @@
                 
                 <Button Grid.Column="1"
                         Content="✕"
+                        AutomationProperties.Name="Clear Search"
                         Command="{Binding ClearSearchCommand}"
                         Width="40"
                         Height="40"

--- a/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
@@ -74,6 +74,7 @@
                                    Margin="0,0,0,15"/>
 
                         <Button Content="📁 Select Image File" 
+                                AutomationProperties.Name="Select Image File"
                                 Command="{Binding ScanFromFileCommand}"
                                 Padding="20,10"
                                 HorizontalAlignment="Left"
@@ -133,10 +134,12 @@
                                             Orientation="Horizontal" 
                                             Margin="0,10,0,0">
                                     <Button Content="📋 Copy" 
+                                            AutomationProperties.Name="Copy"
                                             Command="{Binding CopyBarcodeCommand}"
                                             Padding="15,5"
                                             Margin="0,0,10,0"/>
                                     <Button Content="🗑️ Clear" 
+                                            AutomationProperties.Name="Clear scan"
                                             Command="{Binding ClearScanCommand}"
                                             Padding="15,5"
                                             Style="{StaticResource DefaultButtonStyle}"/>
@@ -295,11 +298,13 @@
                         <!-- Action Buttons -->
                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                             <Button Content="⚙️ Generate" 
+                                    AutomationProperties.Name="Generate"
                                     Command="{Binding GenerateBarcodeCommand}"
                                     Padding="20,10"
                                     Margin="0,0,10,0"
                                     Style="{StaticResource AccentButtonStyle}"/>
                             <Button Content="🗑️ Clear" 
+                                    AutomationProperties.Name="Clear generate"
                                     Command="{Binding ClearGenerateCommand}"
                                     Padding="20,10"
                                     Style="{StaticResource DefaultButtonStyle}"/>
@@ -335,6 +340,7 @@
                         </Border>
 
                         <Button Content="💾 Save Barcode" 
+                                AutomationProperties.Name="Save Barcode"
                                 Command="{Binding SaveBarcodeCommand}"
                                 Padding="20,10"
                                 Margin="0,15,0,0"


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` to WPF `Button` elements that use text-based icons or emojis in their content across `ScanBarcodeWindow.xaml` and `GlobalSearchWindow.xaml`.
🎯 Why: Screen readers read literal emojis (e.g., "wastebasket clear button") when they are used as or alongside button content. Adding `AutomationProperties.Name` provides a clean, text-only ARIA-equivalent label for assistive technologies.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improved screen reader announcements for functional buttons containing emojis or text-based icons, preventing confusing auditory feedback.

---
*PR created automatically by Jules for task [6792975653246354239](https://jules.google.com/task/6792975653246354239) started by @michaelleungadvgen*