### PR TITLE
🎨 Palette: [a11y] Screen reader labels for icon-only buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Chat/PriceChatWindow.xaml
@@ -113,6 +113,7 @@
 
                 <Button Grid.Column="1" 
                         Content="✕" 
+                        AutomationProperties.Name="Close chat"
                         Width="30" 
                         Height="30"
                         Background="Transparent"
@@ -301,6 +302,7 @@
 
                 <Button Grid.Column="1"
                         Content="🗑️"
+                        AutomationProperties.Name="Clear chat"
                         FontSize="16"
                         Width="40"
                         Height="40"
@@ -312,6 +314,7 @@
 
                 <Button Grid.Column="2"
                         Content="➤"
+                        AutomationProperties.Name="Send message"
                         FontSize="16"
                         Width="45"
                         Height="45"

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -48,6 +48,7 @@
                 
                 <Button Grid.Column="1"
                         Content="✕"
+                        AutomationProperties.Name="Clear search"
                         Command="{Binding ClearSearchCommand}"
                         Width="40"
                         Height="40"

--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" AutomationProperties.Name="Toggle favorite" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` attributes to several icon-only buttons across the WPF application (e.g., Close, Delete, Send, Toggle Favorite).
🎯 Why: Icon-only buttons (like `Content="✕"`) are read literally or ignored by screen readers like Narrator or NVDA, making them inaccessible. Providing an explicit Automation Name acts like an `aria-label`, ensuring visually impaired users understand the button's function.
📸 Before/After: Visuals remain exactly the same.
♿ Accessibility: Ensures correct vocalization for users relying on screen readers (WCAG 4.1.2 Name, Role, Value).

---
*PR created automatically by Jules for task [7213899455995248833](https://jules.google.com/task/7213899455995248833) started by @michaelleungadvgen*