### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-05-15 - Middleware Path Matching Bypass
+**Vulnerability:** Authorization and rate-limiting middleware were using `.Contains("/health")` and `.Contains("/swagger")` to bypass checks on specific endpoints. This allowed attackers to bypass security by appending these strings to any protected URL (e.g., `/api/secure-data/health`).
+**Learning:** Using substring matching for security routing exclusions is dangerous and prone to manipulation.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for middleware routing exclusions.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `ApiKeyMiddleware` and `RateLimitMiddleware` used `.Contains("/health")` and `.Contains("/swagger")` to skip security checks on public endpoints. This allows an attacker to bypass API key validation and rate limiting on any protected route simply by appending those strings to the end of a URL (e.g., `/api/admin/users?bypass=/health`).
🎯 Impact: Attackers can completely bypass API key requirements and rate limiting protections for the entire API, potentially leading to unauthorized data access, modification, or Denial of Service (DoS) attacks.
🔧 Fix: Updated the path matching logic in both middleware classes to use `.StartsWith()` instead of `.Contains()`, ensuring that only the actual intended paths are excluded from the checks. Added an entry to the Sentinel journal documenting the learning.
✅ Verification: Tested the server project (`dotnet test -p:EnableWindowsTargeting=true AdvGenPriceComparer.Tests/AdvGenPriceComparer.Tests.csproj --filter "FullyQualifiedName~AdvGenPriceComparer.Server"`) and visually verified the `git diff` output.

---
*PR created automatically by Jules for task [15425804843150938303](https://jules.google.com/task/15425804843150938303) started by @michaelleungadvgen*