### PR TITLE
🎨 Palette: Add AutomationProperties.Name to star button

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/StaticPeerConfigWindow.xaml
@@ -272,7 +272,7 @@
                         <Button Content="Edit" Padding="10,3" Command="{Binding EditPeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Button Content="Delete" Padding="10,3" Command="{Binding DeletePeerCommand}" CommandParameter="{Binding SelectedPeer}"/>
                         <Separator/>
-                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}"/>
+                        <Button Content="★" Padding="10,3" Command="{Binding TogglePeerFavoriteCommand}" CommandParameter="{Binding SelectedPeer}" AutomationProperties.Name="Toggle favorite peer"/>
                         <Button Content="Health" Padding="10,3" Command="{Binding CheckPeerHealthCommand}" CommandParameter="{Binding SelectedPeer}"/>
                     </ToolBar>
                 </ToolBarTray>


### PR DESCRIPTION
**💡 What:**
Added `AutomationProperties.Name="Toggle favorite peer"` to the icon-only "★" button in the `StaticPeerConfigWindow.xaml` toolbar.

**🎯 Why:**
Icon-only buttons using text symbols (like "★") are often announced poorly or confusingly by screen readers (e.g., just reading out "black star"). Providing an explicit `AutomationProperties.Name` ensures assistive technologies announce the actual action ("Toggle favorite peer"), making the interface far more intuitive for visually impaired users. 

**📸 Before/After:**
*Visuals remain unchanged. This is an underlying accessibility API fix.*

**♿ Accessibility:**
Improves screen reader navigation and action comprehension by providing an ARIA-equivalent label for an icon-only control.

---
*PR created automatically by Jules for task [11974900364505578540](https://jules.google.com/task/11974900364505578540) started by @michaelleungadvgen*