### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-05-01 - Authorization Bypass via Path String Matching
+**Vulnerability:** API key middleware and Rate Limiting middleware used `path.Contains("/swagger")` and `path.Contains("/health")` instead of exact path matching or `path.StartsWith()`.
+**Learning:** Using substring matching for security routing rules allows an attacker to easily bypass security controls by appending the ignored string as a query parameter or creating a fake endpoint (e.g., `/api/prices?x=/swagger` or `/api/swagger-fake-endpoint`).
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for security-critical route exclusions in ASP.NET Core middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API key and rate-limiting middleware used substring matching `path.Contains("/swagger")` and `path.Contains("/health")` to skip security checks. An attacker could bypass these checks by appending those strings to any path (e.g., `/api/prices?x=/swagger` or `/api/swagger-fake-endpoint`).
🎯 Impact: Attackers could bypass authentication and rate limits.
🔧 Fix: Updated the logic to use `path.StartsWith("/swagger")` and `path.StartsWith("/health")`.
✅ Verification: Ran unit tests with `dotnet test -p:EnableWindowsTargeting=true AdvGenPriceComparer.sln --filter "FullyQualifiedName~AdvGenPriceComparer.Server"`. Tested `dotnet build`. No regressions found. Updated `.jules/sentinel.md` with learnings.

---
*PR created automatically by Jules for task [18356393160416215726](https://jules.google.com/task/18356393160416215726) started by @michaelleungadvgen*