### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-05-02 - Substring Path Matching Auth/Rate Limit Bypass [RESOLVED]
+**Vulnerability:** Middleware exclusions used `path.Contains("/swagger")` and `path.Contains("/health")` instead of prefix matching.
+**Learning:** Using substring matching for URL path rules allows attackers to bypass authentication or rate limiting by appending the excluded string to protected endpoints (e.g., `/api/prices/upload?bypass=/health`).
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for route-based security rules.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `ApiKeyMiddleware` and `RateLimitMiddleware` used `path.Contains("/health")` and `path.Contains("/swagger")` to bypass API key validation and rate limiting. 
🎯 **Impact:** An attacker could bypass authentication and rate limits on protected endpoints (e.g., `/api/prices/upload`) simply by appending `?bypass=/health` or `/health` to the end of the requested URL.
🔧 **Fix:** Changed the exclusion logic to use `path.StartsWith()` instead of `path.Contains()`.
✅ **Verification:** Verified that building the API and running test suites `AdvGenPriceComparer.Tests` complete without errors. Verified via code review.

---
*PR created automatically by Jules for task [13595827846151207727](https://jules.google.com/task/13595827846151207727) started by @michaelleungadvgen*