### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-03-05 - Auth/Rate Limit Bypass via Substring Matching
+**Vulnerability:** Used `path.Contains()` instead of `path.StartsWith()` for middleware exclusions.
+**Learning:** This allowed bypassing API key authentication and rate limiting by appending `/swagger` or `/health` to any endpoint.
+**Prevention:** Always use exact matching or prefix matching (`StartsWith`) for routing exclusions in custom middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The custom `ApiKeyMiddleware` and `RateLimitMiddleware` used substring matching (`path.Contains("/swagger")` and `path.Contains("/health")`) to exclude paths from validation and rate limiting.
🎯 **Impact:** An attacker could bypass API key authentication and rate limiting for any endpoint by simply appending `/swagger` or `/health` to the request path (e.g., `/api/sensitive-endpoint/swagger`).
🔧 **Fix:** Changed the path exclusion logic from `.Contains()` to exact prefix matching using `.StartsWith()`.
✅ **Verification:** 
1. The modified middleware files were manually inspected to confirm `.StartsWith()` is correctly applied.
2. Ran `dotnet test -p:EnableWindowsTargeting=true AdvGenPriceComparer.sln --filter "FullyQualifiedName~AdvGenPriceComparer.Server"` to ensure backend logic remains functional and tests pass.

---
*PR created automatically by Jules for task [18243945420083387063](https://jules.google.com/task/18243945420083387063) started by @michaelleungadvgen*