### PR TITLE
🛡️ Sentinel: [HIGH] Fix path matching authorization bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2024-05-04 - Path Matching Vulnerability in Middleware
+**Vulnerability:** API Key and Rate Limit middleware used `.Contains("/swagger")` and `.Contains("/health")` for path exclusions, allowing authorization and rate limiting bypass if an attacker crafted a URL like `/api/prices/update?id=1&fake=/swagger`.
+**Learning:** Using substring matching (`Contains`) for routing exclusions creates a bypass vulnerability where restricted endpoints can be accessed by injecting the excluded substring elsewhere in the path.
+**Prevention:** Always use exact or prefix path matching (`StartsWith` or `Equals`) when validating paths for security-sensitive middleware exclusions.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limit middleware used `.Contains("/swagger")` and `.Contains("/health")` for path exclusions, which allows an attacker to bypass authorization and rate limiting by appending `/swagger` or `/health` to sensitive API endpoints.
🎯 Impact: Unauthorized access to protected API endpoints and bypass of rate limits, potentially leading to data exposure or denial of service.
🔧 Fix: Replaced `.Contains` with `.StartsWith` to ensure exact prefix path matching.
✅ Verification: Tested the server project locally using `dotnet test` to confirm there are no regressions. Added an entry to `.jules/sentinel.md` to document the finding.

---
*PR created automatically by Jules for task [11889523629153386164](https://jules.google.com/task/11889523629153386164) started by @michaelleungadvgen*