### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/DealExpirationRemindersWindow.xaml
@@ -222,6 +222,8 @@
                     Command="{Binding DismissAllCommand}"
                     Style="{StaticResource ButtonStyle}"/>
             <Button Content="🗑 Clear Dismissed" 
+                    ToolTip="Clear Dismissed Reminders"
+                    AutomationProperties.Name="Clear Dismissed Reminders"
                     Command="{Binding ClearDismissedCommand}"
                     Style="{StaticResource SecondaryButtonStyle}"/>
         </StackPanel>

--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -48,6 +48,8 @@
                 
                 <Button Grid.Column="1"
                         Content="✕"
+                        ToolTip="Close Search"
+                        AutomationProperties.Name="Close Search"
                         Command="{Binding ClearSearchCommand}"
                         Width="40"
                         Height="40"

--- a/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceAlertWindow.xaml
@@ -160,6 +160,8 @@
                             Padding="10,5"/>
                     <Separator/>
                     <Button Content="🗑 Delete" 
+                            ToolTip="Delete Alert"
+                            AutomationProperties.Name="Delete Alert"
                             Command="{Binding DeleteAlertCommand}"
                             CommandParameter="{Binding SelectedAlert}"
                             Padding="10,5"/>

--- a/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/PriceDropNotificationsWindow.xaml
@@ -96,9 +96,15 @@
                     <Button Content="🔄 Refresh" Command="{Binding RefreshCommand}" Padding="10,5"/>
                     <Separator/>
                     <Button Content="✓ Mark All Read" Command="{Binding MarkAsReadCommand}" Padding="10,5"/>
-                    <Button Content="🗑 Clear All" Command="{Binding ClearAllCommand}" Padding="10,5"/>
+                    <Button Content="🗑 Clear All"
+                            ToolTip="Clear All Notifications"
+                            AutomationProperties.Name="Clear All Notifications"
+                            Command="{Binding ClearAllCommand}" Padding="10,5"/>
                     <Separator/>
-                    <Button Content="✕ Close" Command="{Binding CloseCommand}" Padding="10,5" ToolTip="Close window (Esc)"/>
+                    <Button Content="✕ Close"
+                            ToolTip="Close window (Esc)"
+                            AutomationProperties.Name="Close Notifications Window"
+                            Command="{Binding CloseCommand}" Padding="10,5"/>
                 </ToolBar>
             </ToolBarTray>
 

--- a/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/ScanBarcodeWindow.xaml
@@ -137,6 +137,8 @@
                                             Padding="15,5"
                                             Margin="0,0,10,0"/>
                                     <Button Content="🗑️ Clear" 
+                                            ToolTip="Clear Scan"
+                                            AutomationProperties.Name="Clear Scan"
                                             Command="{Binding ClearScanCommand}"
                                             Padding="15,5"
                                             Style="{StaticResource DefaultButtonStyle}"/>
@@ -300,6 +302,8 @@
                                     Margin="0,0,10,0"
                                     Style="{StaticResource AccentButtonStyle}"/>
                             <Button Content="🗑️ Clear" 
+                                    ToolTip="Clear Generate"
+                                    AutomationProperties.Name="Clear Generate"
                                     Command="{Binding ClearGenerateCommand}"
                                     Padding="20,10"
                                     Style="{StaticResource DefaultButtonStyle}"/>


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` and `ToolTip` to various icon-only buttons (using text/emojis) across several WPF Views (GlobalSearch, ScanBarcode, PriceAlert, DealExpirationReminders, PriceDropNotifications).
🎯 Why: Without explicit automation names, screen readers in WPF fail to meaningfully announce icon-only buttons (like "✕" or "🗑"), degrading accessibility for vision-impaired users. This ensures parity with standard web ARIA labels.
📸 Before/After: Visuals are unchanged. The accessibility tree now accurately reflects the button purposes (e.g. "Close Search" instead of just "✕").
♿ Accessibility: Ensures assistive technologies can identify the purpose of critical action buttons.

---
*PR created automatically by Jules for task [13133160138323588093](https://jules.google.com/task/13133160138323588093) started by @michaelleungadvgen*