### PR TITLE
🎨 Palette: Add accessible label to Clear Search button

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/GlobalSearchWindow.xaml
@@ -49,6 +49,8 @@
                 <Button Grid.Column="1"
                         Content="✕"
                         Command="{Binding ClearSearchCommand}"
+                        AutomationProperties.Name="Clear search"
+                        ToolTip="Clear search"
                         Width="40"
                         Height="40"
                         Background="Transparent"


### PR DESCRIPTION
💡 What: Added `AutomationProperties.Name` and `ToolTip` to the '✕' (Clear Search) button in the Global Search window.
🎯 Why: Icon-only buttons or buttons using just symbols need a descriptive label so screen readers announce their function clearly instead of just reading out a symbol character (like "Multiply").
📸 Before/After: N/A
♻️ Accessibility: Improves screen reader accessibility for the clear search action.

---
*PR created automatically by Jules for task [2253781363348987576](https://jules.google.com/task/2253781363348987576) started by @michaelleungadvgen*