### PR TITLE
🎨 Palette: Add screen reader names to Cloud Sync buttons

### DIFF
--- a/AdvGenPriceComparer.WPF/Views/CloudSyncStatusWindow.xaml
+++ b/AdvGenPriceComparer.WPF/Views/CloudSyncStatusWindow.xaml
@@ -148,13 +148,17 @@
                         <GroupBox Header="Quick Actions" Margin="0,15,0,0">
                             <WrapPanel Margin="10">
                                 <Button Content="🔄 Sync Now" Style="{StaticResource ActionButton}" 
-                                        Command="{Binding SyncNowCommand}" IsEnabled="{Binding CanSync}"/>
+                                        Command="{Binding SyncNowCommand}" IsEnabled="{Binding CanSync}"
+                                        AutomationProperties.Name="Sync Now"/>
                                 <Button Content="📤 Export to Cloud" Style="{StaticResource ActionButton}" 
-                                        Command="{Binding ExportCommand}" IsEnabled="{Binding CanSync}"/>
+                                        Command="{Binding ExportCommand}" IsEnabled="{Binding CanSync}"
+                                        AutomationProperties.Name="Export to Cloud"/>
                                 <Button Content="📥 Import from Cloud" Style="{StaticResource ActionButton}" 
-                                        Command="{Binding ImportCommand}" IsEnabled="{Binding CanSync}"/>
+                                        Command="{Binding ImportCommand}" IsEnabled="{Binding CanSync}"
+                                        AutomationProperties.Name="Import from Cloud"/>
                                 <Button Content="🔌 Test Connection" Style="{StaticResource ActionButton}" 
-                                        Command="{Binding TestConnectionCommand}" IsEnabled="{Binding CanSync}"/>
+                                        Command="{Binding TestConnectionCommand}" IsEnabled="{Binding CanSync}"
+                                        AutomationProperties.Name="Test Connection"/>
                             </WrapPanel>
                         </GroupBox>
                     </StackPanel>


### PR DESCRIPTION
💡 **What:** Added `AutomationProperties.Name` to the four "Quick Actions" buttons (Sync Now, Export, Import, Test Connection) in the `CloudSyncStatusWindow.xaml` file.
🎯 **Why:** These buttons include emoji characters (like 🔄, 📤, etc.) in their `Content`, which can cause screen readers to announce the emoji symbols literally and awkwardly. 
📸 **Before/After:** No visual changes.
♿ **Accessibility:** By providing explicit, text-only names via `AutomationProperties.Name`, screen readers will announce clean, semantic names (e.g., "Sync Now") instead of a jumbled mix of emoji symbols and text.

---
*PR created automatically by Jules for task [15515865374030519560](https://jules.google.com/task/15515865374030519560) started by @michaelleungadvgen*