### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-05-09 - Authorization and Rate Limit Bypass in Middleware
+**Vulnerability:** Custom `ApiKeyMiddleware` and `RateLimitMiddleware` used `.Contains()` instead of `.StartsWith()` or exact matching for routing exclusions (e.g., bypassing auth for `/swagger` and `/health`). This allowed an attacker to bypass authentication and rate limits on protected API endpoints by appending `/swagger` or `/health` to the path (e.g., `/api/prices/upload/health`).
+**Learning:** Substring matching for URL paths in middleware can be easily exploited to bypass security controls when developers attempt to create generic exclusion rules.
+**Prevention:** Always use strict path matching (`==`) or prefix matching (`.StartsWith()`) when defining route exclusions in custom middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Custom middleware used `Contains()` instead of `StartsWith()` for routing exclusions, allowing attackers to bypass API key validation and rate limiting by appending `/health` or `/swagger` to any API path.
- 🎯 Impact: Attackers could access protected endpoints without an API key or bypass rate limits, potentially leading to unauthorized data modification or DoS.
- 🔧 Fix: Replaced `Contains()` with `StartsWith()` for routing exclusions in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs`. Also added an entry to the `.jules/sentinel.md` journal.
- ✅ Verification: Verified the backend compiles successfully with `dotnet build` and ran the relevant backend test suite filtering for `AdvGenPriceComparer.Server`.

---
*PR created automatically by Jules for task [1634495963633307542](https://jules.google.com/task/1634495963633307542) started by @michaelleungadvgen*