### PR TITLE
🎨 Palette: Add confirmation dialogs for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-05-09 - Add confirmation dialogs for destructive actions
+**Learning:** Discovered that the admin dashboard had destructive actions (delete) without any user confirmation, leading to potential accidental data loss, which is a poor UX.
+**Action:** Used `IJSRuntime.InvokeAsync<bool>("confirm")` to add native browser confirmation dialogs before executing destructive actions in Blazor components. This provides a reusable, lightweight UX pattern for confirmation states.

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
@@ -1,5 +1,6 @@
 @page "/admin/items"
 @attribute [Authorize(Roles = "Admin")]
+@inject IJSRuntime JSRuntime
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
 
@@ -186,8 +187,11 @@
         LoadItems();
     }
 
-    private void DeleteItem(Item item)
+    private async Task DeleteItem(Item item)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete '{item.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeleteItem(item.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
@@ -1,5 +1,6 @@
 @page "/admin/places"
 @attribute [Authorize(Roles = "Admin")]
+@inject IJSRuntime JSRuntime
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
 
@@ -102,8 +103,11 @@
         }
     }
 
-    private void DeletePlace(Place place)
+    private async Task DeletePlace(Place place)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete '{place.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePlace(place.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
@@ -1,5 +1,6 @@
 @page "/admin/price-records"
 @attribute [Authorize(Roles = "Admin")]
+@inject IJSRuntime JSRuntime
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
 
@@ -192,8 +193,11 @@
         return placeCache[record.PlaceId];
     }
 
-    private void DeletePriceRecord(PriceRecord record)
+    private async Task DeletePriceRecord(PriceRecord record)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", "Are you sure you want to delete this price record?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePriceRecord(record.Id);


### PR DESCRIPTION
💡 What: Added JavaScript confirmation dialogs (`window.confirm`) to all delete actions in the Admin dashboard (Items, Places, Price Records).
🎯 Why: Destructive actions like deleting items, places, or price records previously executed immediately upon clicking the delete button. This could lead to accidental data loss. A confirmation step prevents user error and improves the overall experience.
📸 Before/After: Before, clicking delete instantly removed the record. After, clicking delete prompts the user with a confirmation dialog.
♿ Accessibility: Prevents accidental destructive actions, providing a safer interaction model for keyboard and screen reader users navigating the table actions.

---
*PR created automatically by Jules for task [789557930294827007](https://jules.google.com/task/789557930294827007) started by @michaelleungadvgen*