### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API path matching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-05-10 - Path Match Vulnerability in Middleware
+**Vulnerability:** API key and rate-limiting middleware used `.Contains("/swagger")` and `.Contains("/health")` to skip authentication and rate-limiting. A malicious user could craft a request to a protected endpoint like `/api/prices?foo=/swagger` or `/api/prices/swagger` to bypass these critical security controls.
+**Learning:** Substring matching for URL paths in middleware is a common authorization bypass vector. Any uncontrolled segment of the path or query string containing the target string will falsely trigger the exclusion rule.
+**Prevention:** Always use precise path matching (`.StartsWith()`, `.Equals()`, or framework-provided routing constraints) rather than loose substring matching (`.Contains()`) when evaluating request paths for security exclusions.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API key and rate-limiting middleware used loose `.Contains("/swagger")` and `.Contains("/health")` checks to bypass security controls. 
🎯 Impact: A malicious actor could craft a request to a protected endpoint (e.g. `/api/prices/swagger` or `/api/prices?foo=/swagger`) and completely bypass API key authentication and rate limits.
🔧 Fix: Changed `.Contains()` substring matching to precise `.StartsWith()` prefix matching for the `/swagger` and `/health` paths.
✅ Verification: Ran `dotnet build AdvGenPriceComparer.Server/AdvGenPriceComparer.Server.csproj` and backend tests via `dotnet test AdvGenPriceComparer.Tests/AdvGenPriceComparer.Tests.csproj -p:EnableWindowsTargeting=true --filter "FullyQualifiedName~AdvGenPriceComparer.Server"` to ensure it compiles and has no regressions.

---
*PR created automatically by Jules for task [15835243195382965769](https://jules.google.com/task/15835243195382965769) started by @michaelleungadvgen*