### PR TITLE
🎨 Palette: Add confirmation dialogs to destructive actions

### DIFF
--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Items - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -186,8 +187,11 @@
         LoadItems();
     }
 
-    private void DeleteItem(Item item)
+    private async Task DeleteItem(Item item)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete the item '{item.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeleteItem(item.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Places - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -102,8 +103,11 @@
         }
     }
 
-    private void DeletePlace(Place place)
+    private async Task DeletePlace(Place place)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete the place '{place.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePlace(place.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Price Records - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -192,8 +193,11 @@
         return placeCache[record.PlaceId];
     }
 
-    private void DeletePriceRecord(PriceRecord record)
+    private async Task DeletePriceRecord(PriceRecord record)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", "Are you sure you want to delete this price record?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePriceRecord(record.Id);


### PR DESCRIPTION
* 💡 **What:** Added browser native confirmation dialogs to delete operations in the Items, Places, and Price Records administration pages.
* 🎯 **Why:** To prevent accidental deletions of critical data by prompting the user to confirm their intent before executing the destructive action.
* 📸 **Before/After:** No major visual layout changes; triggers the standard browser `confirm()` popup when clicking "Delete".
* ♿ **Accessibility:** Adding explicit confirmation for destructive actions improves overall usability and helps prevent accidental data loss for all users.

---
*PR created automatically by Jules for task [16368028386587284475](https://jules.google.com/task/16368028386587284475) started by @michaelleungadvgen*