### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in custom middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-02-28 - Insecure Path Matching in Middleware [RESOLVED]
+**Vulnerability:** Custom ASP.NET Core middleware (`ApiKeyMiddleware` and `RateLimitMiddleware`) used `Contains()` instead of `StartsWith()` for path exclusions. This allowed attackers to bypass API key validation and rate limiting by appending `/health` or `/swagger` to any URL (e.g., `/api/prices/upload/health`).
+**Learning:** Substring matching for routing exclusions is highly susceptible to path traversal or parameter manipulation attacks. Attackers can easily craft URLs that satisfy the substring condition while accessing protected endpoints.
+**Prevention:** Always use exact matching or prefix path matching (`StartsWith()`) for routing exclusions in custom middleware to ensure robust security and prevent unauthorized access or rate limiting bypasses.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH\n💡 Vulnerability: Custom middleware used `Contains()` instead of `StartsWith()` for path exclusions, allowing attackers to bypass API key validation and rate limiting by appending `/health` or `/swagger` to any URL (e.g., `/api/prices/upload/health`).\n🎯 Impact: Attackers could upload unauthorized data, bypass rate limits, and potentially cause a denial of service.\n🔧 Fix: Replaced insecure `Contains()` substring matching with secure `StartsWith()` prefix matching for routing exclusions.\n✅ Verification: Server compilation succeeds and existing tests pass.

---
*PR created automatically by Jules for task [5632964338314221623](https://jules.google.com/task/5632964338314221623) started by @michaelleungadvgen*