### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middlewares

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-05-11 - Middleware Exclusion Bypass [RESOLVED]
+**Vulnerability:** Custom ASP.NET Core middleware (`ApiKeyMiddleware` and `RateLimitMiddleware`) used `path.Contains()` instead of exact or prefix matching for routing exclusions (e.g., `/health`, `/swagger`).
+**Learning:** Using `Contains()` for path exclusions allows attackers to bypass authorization and rate limiting by simply appending the excluded string to any protected path (e.g., `/api/protected/health`).
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for middleware routing exclusions to prevent path manipulation bypasses.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limiting middlewares used `Contains()` instead of `StartsWith()` for path exclusions, allowing attackers to bypass authentication and rate limits by appending `/health` or `/swagger` to any API path (e.g., `/api/secure-endpoint/health`).
🎯 Impact: Attackers could bypass API key validation and rate limiting on protected endpoints, potentially leading to unauthorized data access or denial of service.
🔧 Fix: Updated the middleware path exclusion logic to use `StartsWith()` instead of `Contains()`, ensuring only paths explicitly starting with the allowed prefixes are excluded.
✅ Verification: Server builds successfully. Requests to endpoints with `/health` appended will now correctly trigger API key validation and rate limiting.

---
*PR created automatically by Jules for task [2281945433166285307](https://jules.google.com/task/2281945433166285307) started by @michaelleungadvgen*