### PR TITLE
🎨 Palette: Add confirmation dialogs for admin delete actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2025-05-11 - Adding Confirmation to Destructive Actions
+**Learning:** Blazor's `@onclick` handlers naturally support upgrading from a synchronous `void` method to an asynchronous `Task` method without any syntax changes in the markup. This makes it trivial to insert `await JSRuntime.InvokeAsync<bool>("confirm", ...)` to add a native browser confirmation dialog before executing a potentially destructive operation, such as a delete.
+**Action:** When implementing destructive operations in Blazor, inject `IJSRuntime` and evaluate native browser `confirm` dialogs, converting synchronous click event handlers to `async Task` to enable awaiting the result.

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Items - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -186,8 +187,11 @@
         LoadItems();
     }
 
-    private void DeleteItem(Item item)
+    private async Task DeleteItem(Item item)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete '{item.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeleteItem(item.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Places - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -102,8 +103,11 @@
         }
     }
 
-    private void DeletePlace(Place place)
+    private async Task DeletePlace(Place place)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete '{place.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePlace(place.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Price Records - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -192,8 +193,11 @@
         return placeCache[record.PlaceId];
     }
 
-    private void DeletePriceRecord(PriceRecord record)
+    private async Task DeletePriceRecord(PriceRecord record)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", "Are you sure you want to delete this price record?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePriceRecord(record.Id);


### PR DESCRIPTION
## 💡 What
Added native browser confirmation dialogs (`confirm`) before executing destructive delete actions in the Admin interface for Items, Places, and PriceRecords.

## 🎯 Why
To prevent accidental data loss. Clicking a "Delete" button previously immediately deleted the record without any confirmation. Now, users must explicitly confirm their intent, reducing the risk of mistakes.

## 📸 Before/After
**Before:** Clicking "Delete" immediately executes the delete operation.
**After:** Clicking "Delete" prompts the user with a browser confirmation dialog: "Are you sure you want to delete '[Item Name]'?".

## ♿ Accessibility
Improves overall usability by adhering to standard UX heuristics for destructive actions, providing an escape hatch before data is irreversibly modified.

---
*PR created automatically by Jules for task [942387469239007834](https://jules.google.com/task/942387469239007834) started by @michaelleungadvgen*