### PR TITLE
🎨 Palette: Enhance keyboard a11y and semantic navigation for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2025-05-12 - Replacing div+onclick with anchor tags for card navigation
+**Learning:** Using `div` with `@onclick` for navigation cards completely breaks keyboard accessibility, screen reader focus, and standard browser features (like middle-click to open in new tab).
+**Action:** Always use semantic `<a>` tags with `href` for interactive cards that navigate to a new route, applying styles (`text-decoration-none text-dark display: block`) to maintain the card visual structure while restoring native accessibility.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -15,12 +15,13 @@
                     <div class="input-group">
                         <span class="input-group-text"><i class="bi bi-search"></i></span>
                         <input type="text" class="form-control" placeholder="Search items..."
+                               aria-label="Search items"
                                @bind="searchTerm" @bind:event="oninput" @onkeyup="HandleSearch" />
                         <button class="btn btn-primary" @onclick="ApplyFilters">Search</button>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <select class="form-select" @bind="selectedCategory">
+                    <select class="form-select" aria-label="Filter by category" @bind="selectedCategory">
                         <option value="">All Categories</option>
                         @foreach (var category in categories)
                         {
@@ -58,7 +59,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="cursor: pointer;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +74,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +216,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }

--- a/AdvGenPriceComparer.Web/Components/Pages/Deals.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Deals.razor
@@ -52,7 +52,7 @@
                                 <small class="text-muted">
                                     <i class="bi bi-shop"></i> @deal.BestStore?.Name
                                 </small>
-                                <a href="item/@deal.Item?.Id" class="btn btn-outline-primary btn-sm">Details</a>
+                                <a href="item/@deal.Item?.Id" class="btn btn-outline-primary btn-sm" aria-label="View details for @deal.Item?.Name">Details</a>
                             </div>
                         </div>
                     </div>

--- a/AdvGenPriceComparer.Web/Components/Pages/Home.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Home.razor
@@ -47,7 +47,7 @@
                                 </div>
                             </div>
                             <div class="card-footer bg-transparent">
-                                <a href="item/@deal.Item?.Id" class="btn btn-outline-primary btn-sm w-100">View Details</a>
+                                <a href="item/@deal.Item?.Id" class="btn btn-outline-primary btn-sm w-100" aria-label="View details for @deal.Item?.Name">View Details</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the interactive 'div' card wrapper in Browse.razor with a semantic 'a' tag. Added missing ARIA labels to search inputs, filter dropdowns, and "Details" buttons across Home, Deals, and Browse pages.\n\n🎯 **Why:** The previous implementation using 'div' with '@onclick' broke basic keyboard navigation (tabbing), prevented standard browser interactions (like right-click or middle-click to open in a new tab), and was unsemantic for screen readers.\n\n♿ **Accessibility:** Restored native keyboard focus and interaction to the browse cards. Provided meaningful context to screen readers for form inputs and generic "Details" links by associating them with the item name.

---
*PR created automatically by Jules for task [246905895986491507](https://jules.google.com/task/246905895986491507) started by @michaelleungadvgen*