### PR TITLE
🎨 Palette: Add confirmation dialogs for destructive delete actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,10 +1,4 @@
+## 2025-05-13 - Blazor Confirmation Dialogs
 
-## 2024-05-23 - Screen Reader Accessibility in WPF
-**Learning:** The existing ToolTip attributes on icon-only buttons are insufficient for screen readers in WPF. Screen readers rely on the AutomationProperties.Name attached property to announce elements correctly.
-**Action:** Explicitly define AutomationProperties.Name on all icon-only buttons in WPF XAML files to ensure they are accessible to assistive technologies.
-
-
-## 2025-02-17 - WPF Icon-only Button Accessibility
-**Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
-**Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
-
+**Learning:** The project relies on standard `confirm()` dialogs via JS interop rather than custom UI components for destructive action confirmations. This pattern is simpler but requires converting synchronous event handlers to `async Task` methods in Blazor.
+**Action:** Use `await JSRuntime.InvokeAsync<bool>("confirm", ...)` when adding confirmations to `@onclick` handlers in `.razor` files, ensuring `IJSRuntime` is injected.

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Items - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -186,8 +187,11 @@
         LoadItems();
     }
 
-    private void DeleteItem(Item item)
+    private async Task DeleteItem(Item item)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete the item '{item.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeleteItem(item.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Places - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -102,8 +103,11 @@
         }
     }
 
-    private void DeletePlace(Place place)
+    private async Task DeletePlace(Place place)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete the place '{place.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePlace(place.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Price Records - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -192,8 +193,16 @@
         return placeCache[record.PlaceId];
     }
 
-    private void DeletePriceRecord(PriceRecord record)
+    private async Task DeletePriceRecord(PriceRecord record)
     {
+        var item = GetItemForRecord(record);
+        var place = GetPlaceForRecord(record);
+        string itemName = item?.Name ?? "Unknown Item";
+        string placeName = place?.Name ?? "Unknown Place";
+
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete the price record for '{itemName}' at '{placeName}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePriceRecord(record.Id);


### PR DESCRIPTION
💡 What: Added native browser confirmation dialogs (`confirm()`) to the 'Delete' buttons on the Admin Items, Places, and Price Records pages.
🎯 Why: Prevents accidental deletion of critical data by requiring explicit user confirmation for destructive actions.
📸 Before/After: Before, clicking 'Delete' immediately removed the record. After, clicking 'Delete' prompts a browser confirmation dialog with the item/place name.
♿ Accessibility: Improves error prevention, aligning with WCAG 3.3.4 Error Prevention (Legal, Financial, Data).

---
*PR created automatically by Jules for task [10261768326004718535](https://jules.google.com/task/10261768326004718535) started by @michaelleungadvgen*