### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-05-14 - Authorization and Rate Limit Bypass via Insecure Path Matching
+**Vulnerability:** Custom middleware (`ApiKeyMiddleware` and `RateLimitMiddleware`) used `path.Contains("/swagger")` and `path.Contains("/health")` to skip authentication and rate limiting for specific endpoints. This allows an attacker to append `/swagger` or `/health` anywhere in the path (e.g., `/api/prices/upload/swagger`) to bypass these security controls.
+**Learning:** Using substring matching (`Contains()`) for routing security exceptions is a common anti-pattern that leads to authorization and rate limit bypasses.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for middleware path exclusions to ensure the bypass only applies to the intended root paths.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limit middleware used insecure substring matching (`Contains`) to exclude specific paths (like `/swagger` and `/health`).
🎯 Impact: Attackers could bypass authentication and rate limits by appending the excluded strings anywhere in the request path (e.g., `/api/admin/sensitive/swagger`), allowing unauthorized access to protected endpoints and unbounded requests.
🔧 Fix: Updated the path exclusion logic in both middlewares to use prefix matching (`StartsWith()`) instead of substring matching.
✅ Verification: `dotnet build` succeeds and the tests pass successfully.

---
*PR created automatically by Jules for task [7620435575705484327](https://jules.google.com/task/7620435575705484327) started by @michaelleungadvgen*