### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in path matching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Authorization Bypass in Middleware Path Matching
+**Vulnerability:** Custom ASP.NET Core middlewares (`ApiKeyMiddleware`, `RateLimitMiddleware`) used `path.Contains()` for exclusions, allowing attackers to bypass authentication and rate limits by appending `/swagger` to secure paths.
+**Learning:** Substring matching for URL paths is a critical security risk when used for authorization exclusions.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) when excluding paths from security middlewares.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Custom middlewares used substring matching (`.Contains()`) for path exclusions, creating an authorization bypass risk.
🎯 Impact: Attackers could bypass API key validation and rate limits by appending `/swagger` or `/health` to any secure endpoint path.
🔧 Fix: Replaced `.Contains()` with `.StartsWith()` for accurate path evaluation.
✅ Verification: Code builds successfully, middlewares correctly evaluate prefixes, and tests pass.

---
*PR created automatically by Jules for task [745159928431787348](https://jules.google.com/task/745159928431787348) started by @michaelleungadvgen*