### PR TITLE
🎨 Palette: Add confirmation dialogs for destructive delete actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2026-05-15 - Native Browser Confirmation Dialogs in Blazor
+**Learning:** Missing confirmation for destructive actions (like delete) can cause accidental data loss. This can be resolved effectively using native browser confirm dialogs in Blazor via IJSRuntime.
+**Action:** Always inject IJSRuntime and use await JSRuntime.InvokeAsync<bool>("confirm", "...") before executing destructive operations in Blazor components.

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Items - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -186,8 +187,11 @@
         LoadItems();
     }
 
-    private void DeleteItem(Item item)
+    private async Task DeleteItem(Item item)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete the item '{item.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeleteItem(item.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Places - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -102,8 +103,11 @@
         }
     }
 
-    private void DeletePlace(Place place)
+    private async Task DeletePlace(Place place)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete the place '{place.Name}'?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePlace(place.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Price Records - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -192,8 +193,11 @@
         return placeCache[record.PlaceId];
     }
 
-    private void DeletePriceRecord(PriceRecord record)
+    private async Task DeletePriceRecord(PriceRecord record)
     {
+        bool confirmed = await JSRuntime.InvokeAsync<bool>("confirm", "Are you sure you want to delete this price record?");
+        if (!confirmed) return;
+
         try
         {
             WebDataService.DeletePriceRecord(record.Id);


### PR DESCRIPTION
💡 What: Added native browser confirmation dialogs when deleting items, places, and price records in the admin dashboard.\n🎯 Why: Prevents accidental data loss by prompting the user before performing destructive actions.\n📸 Before/After: Clicking "Delete" now prompts a confirmation dialog instead of immediately deleting.\n♿ Accessibility: Leverages the native browser confirmation dialog which is natively accessible to screen readers.

---
*PR created automatically by Jules for task [16633510976547582734](https://jules.google.com/task/16633510976547582734) started by @michaelleungadvgen*