### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-03-01 - Middleware Authorization and Rate Limit Bypass [RESOLVED]
+**Vulnerability:** Path exclusion checks in custom middleware (`ApiKeyMiddleware` and `RateLimitMiddleware`) used `Contains()` instead of exact or prefix matching, allowing attackers to bypass authentication and rate limits by appending the excluded string (like `/swagger`) to any URL (e.g., `/api/admin/swagger`).
+**Learning:** Substring matching (`Contains()`) for routing or authorization exclusions creates critical vulnerabilities. A request to `/api/sensitive/health` might bypass security checks completely.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) when excluding paths from security middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Custom middleware (`ApiKeyMiddleware` and `RateLimitMiddleware`) used `Contains()` to skip checks for paths with `/swagger` or `/health`. This allows an attacker to bypass API key validation and rate limiting entirely for any endpoint by simply including those substrings in the request path (e.g., `/api/prices/health`).
🎯 Impact: Attackers can bypass authentication and rate-limiting, potentially gaining unauthorized access to sensitive endpoints or executing Denial of Service (DoS) attacks.
🔧 Fix: Replaced `path.Contains()` with `path.StartsWith()` to ensure that only exact or prefixed paths (e.g., `/swagger/*`) are excluded from security checks.
✅ Verification: Review the updated middleware files to confirm `StartsWith` is used. Build and tests verify the changes don't break existing functionality.

---
*PR created automatically by Jules for task [4752468266166781181](https://jules.google.com/task/4752468266166781181) started by @michaelleungadvgen*