### PR TITLE
🎨 Palette: Semantic Links for Item Cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2025-05-16 - Semantic Navigation in Blazor
+**Learning:** Using `<div>` elements with `@onclick` for navigation in Blazor breaks keyboard accessibility and native browser functions (like middle-clicking to open in a new tab).
+**Action:** Always replace them with semantic `<a>` tags pointing to the correct route using `href` and apply utility classes like `text-decoration-none text-dark` to preserve visual layout.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Converted the item cards in Browse.razor from interactive `<div>` elements with `@onclick` handlers to semantic `<a>` link elements.
🎯 Why: Restores keyboard navigation and native browser functionalities (like middle-click opening in a new tab) which were broken by using a div.
📸 Before/After: Visual presentation remains exactly the same, applying text-decoration-none.
♿ Accessibility: Improves screen reader compatibility and keyboard navigation by using semantically correct HTML link elements instead of simulated interactions.

---
*PR created automatically by Jules for task [17852499749079480250](https://jules.google.com/task/17852499749079480250) started by @michaelleungadvgen*