### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Authorization Bypass via Path Substring Matching [RESOLVED]
+**Vulnerability:** Middleware used `path.Contains("/swagger")` to bypass API key and rate-limiting checks, allowing attackers to access protected endpoints by appending `?path=/swagger` or including it in the route.
+**Learning:** Using substring matching (`Contains`) for security exclusions is highly prone to bypass.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith`) for path exclusions in custom middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limit middleware used `path.Contains()` for path exclusions, which allows an attacker to bypass these protections simply by appending `/swagger` or `/health` to any API request (e.g., `/api/protected/resource?foo=/swagger`).
🎯 Impact: Attackers can bypass API Key authentication and rate limiting entirely on all endpoints, potentially leading to unauthorized data access, DoS, and excessive resource consumption.
🔧 Fix: Replaced `path.Contains()` with `path.StartsWith()` in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs` to correctly restrict bypasses to paths that actually begin with the excluded prefixes.
✅ Verification: Tested the server build and test suite to ensure functionality remains unchanged. Examined the modified middleware to confirm paths are appropriately restricted.

---
*PR created automatically by Jules for task [16908225768337234231](https://jules.google.com/task/16908225768337234231) started by @michaelleungadvgen*