### PR TITLE
🎨 Palette: [Accessibility] Use semantic anchor tags for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-05-17 - Replace div onclick with semantic anchor tag
+**Learning:** Using `<div>` with `@onclick` for navigation in Blazor breaks keyboard accessibility and native browser features (like middle-click). Always replace them with semantic `<a>` tags using `href` when linking to routes, applying utility classes like `text-decoration-none text-dark` to preserve visual styling.
+**Action:** Always scan for `<div onclick>` elements used for navigation and replace them with `<a>` tags for better accessibility and user experience.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced `<div @onclick>` elements with semantic `<a>` tags in `Browse.razor`.
🎯 Why: Using `<div>` for navigation breaks keyboard accessibility, screen readers, and native browser features like middle-clicking to open in a new tab.
♿ Accessibility: Improves keyboard navigation (tabbing) and provides proper link semantics for screen readers.

---
*PR created automatically by Jules for task [4806418853697976195](https://jules.google.com/task/4806418853697976195) started by @michaelleungadvgen*