### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,12 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-02-28 - Authorization Bypass via Substring Path Matching [RESOLVED]
+**Vulnerability:** The API key and rate limit middleware used `.Contains("/swagger")` and `.Contains("/health")` to skip validation for public endpoints. This allowed an attacker to bypass authentication and rate limits on protected routes simply by appending a matching string to the path.
+**Status:** ✅ FIXED - Replaced `.Contains()` with `.StartsWith()` for path exclusion matching.
+**Implementation:**
+- Modified `ApiKeyMiddleware.cs` path checks.
+- Modified `RateLimitMiddleware.cs` path checks.
+**Learning:** Using substring matching (`Contains`) for access control rules on request paths is highly dangerous because it matches anywhere in the URI, often ignoring URL boundaries.
+**Prevention:** In custom ASP.NET Core middleware (e.g., `ApiKeyMiddleware`, `RateLimitMiddleware`), always use exact matching (`==`) or prefix matching (`StartsWith()`) for path exclusions to prevent authorization and rate limit bypass vulnerabilities.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API key and rate limit middleware were using `.Contains("/swagger")` and `.Contains("/health")` to skip validation on public endpoints. This could be exploited by an attacker to bypass authentication and rate limits on protected endpoints by simply embedding `/swagger` or `/health` in the request path (e.g., `/api/prices/swagger/`).
🎯 Impact: Attackers could bypass API key restrictions to access protected data or perform actions without authorization, and bypass rate limits potentially causing denial of service.
🔧 Fix: Replaced `.Contains()` with `.StartsWith()` in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs` for path exclusion checks to ensure exact prefix matching.
✅ Verification: Ensure the server builds and runs. Verify that requests to `/api/prices` without an API key are rejected (401), but requests to `/swagger` or `/health` are allowed. Requests to `/api/prices/swagger` should also be correctly rejected.

---
*PR created automatically by Jules for task [12768455659192909674](https://jules.google.com/task/12768455659192909674) started by @michaelleungadvgen*