### PR TITLE
🎨 Palette: Replace div navigation with semantic links for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-05-18 - Semantic Link Replacements for Blazor Navigation
+**Learning:** Found that using `<div @onclick="NavigateTo">` for card navigation in Blazor lists breaks keyboard accessibility (no tab focus, no enter-to-click) and native browser features like middle-click to open in a new tab.
+**Action:** Replace `<div>` with `<a>` tags using `href="path"` and apply utility classes like `text-decoration-none text-dark` to preserve visual styling while ensuring accessibility.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="display: flex; flex-direction: column;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced a `<div>` containing an `@onclick` handler with a semantic `<a>` tag for item navigation in `Browse.razor`.
🎯 Why: The previous implementation broke keyboard accessibility (couldn't tab to or press Enter on the card) and prevented native browser features like middle-clicking to open in a new tab.
♿ Accessibility: Restored standard tab index and link behavior.

---
*PR created automatically by Jules for task [3806681256830241616](https://jules.google.com/task/3806681256830241616) started by @michaelleungadvgen*