### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2024-05-24 - Authorization Bypass via Substring Matching
+**Vulnerability:** In custom ASP.NET Core middleware (`ApiKeyMiddleware`, `RateLimitMiddleware`), path exclusions for `/swagger` and `/health` endpoints were implemented using `Contains()` instead of `StartsWith()` or exact matching.
+**Learning:** This substring matching creates an authorization and rate limit bypass vulnerability where an attacker could access sensitive endpoints by appending the excluded strings to the path (e.g., `/api/prices/upload/swagger`).
+**Prevention:** In custom middleware, always use exact matching (`==`) or prefix matching (`StartsWith()`) for path exclusions to prevent path-based bypass attacks.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Path-based authorization and rate-limiting bypass. The custom `ApiKeyMiddleware` and `RateLimitMiddleware` used `.Contains("/swagger")` and `.Contains("/health")` to skip enforcement for health check and API documentation endpoints.

🎯 **Impact:** An attacker could append the excluded string to a restricted API path (e.g., `/api/prices/upload/swagger`) and bypass the API Key validation and rate limiting entirely if the routing allowed variable paths, exposing sensitive functionality to unauthenticated or abusive access.

🔧 **Fix:** Replaced `.Contains()` with `.StartsWith()` to enforce prefix matching, ensuring that only requests explicitly starting with `/swagger` or `/health` bypass validation, preventing the injection technique.

✅ **Verification:** Verified by code review that all path matching now securely evaluates the prefix instead of any substring, and confirmed via `dotnet test` that tests remain passing and the application successfully compiles. Also documented the vulnerability pattern and mitigation in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1873632354842427899](https://jules.google.com/task/1873632354842427899) started by @michaelleungadvgen*