### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix authentication and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-05-20 - [Path Exclusion Bypass]
+**Vulnerability:** Substring matching (`Contains`) used for path exclusions in middleware created authentication and rate limit bypass vulnerabilities.
+**Learning:** Using `Contains` allows paths like `/api/prices/swagger` to bypass security checks.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for path exclusions.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Substring matching (`Contains`) was used for path exclusions in `ApiKeyMiddleware` and `RateLimitMiddleware`. This allows an attacker to bypass authentication and rate limits by simply appending `/swagger` or `/health` to any API path (e.g., `/api/prices/swagger`).
🎯 Impact: An attacker could completely bypass API key authentication and rate limiting for all protected endpoints, potentially leading to unauthorized data access, modification, or Denial of Service (DoS) attacks.
🔧 Fix: Replaced `.Contains("/swagger")` and `.Contains("/health")` with `.StartsWith("/swagger")` and `.StartsWith("/health")` in both middleware files.
✅ Verification: Code compiles successfully. The test suite was invoked (though it failed due to pre-existing Linux/WPF targeting issues unrelated to this change). The Sentinel Journal has been updated with this learning.

---
*PR created automatically by Jules for task [9734695202069342213](https://jules.google.com/task/9734695202069342213) started by @michaelleungadvgen*