### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middlewares

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2026-05-20 - Path Exclusion Bypass in ASP.NET Core Middleware [RESOLVED]
+**Vulnerability:** API key and Rate Limit middlewares used `path.Contains("/swagger")` and `path.Contains("/health")` to skip checks. An attacker could bypass authentication and rate limits by appending `/swagger` to any URL (e.g., `/api/prices/upload/swagger`).
+**Learning:** Using substring matching (`.Contains()`) for authorization exclusions is a common anti-pattern that creates critical bypass vulnerabilities.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`.StartsWith()`) for path exclusions in custom ASP.NET Core middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API key and Rate Limit middlewares used `.Contains()` for path exclusions, allowing attackers to bypass authentication and rate limits by appending `/swagger` or `/health` to any protected URL (e.g., `/api/prices/upload/swagger`).
🎯 Impact: Unauthorized users could upload data, access restricted endpoints, and bypass rate limits, potentially leading to data corruption or DoS.
🔧 Fix: Changed `.Contains()` to `.StartsWith()` in path exclusion checks.
✅ Verification: Build the server project and run tests. Attempting to access `/api/prices/upload/swagger` without an API key will now correctly return 401 Unauthorized.

---
*PR created automatically by Jules for task [6351532202883682275](https://jules.google.com/task/6351532202883682275) started by @michaelleungadvgen*