### PR TITLE
🎨 Palette: Semantic links for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-05-20 - Semantic Anchor Tags in Blazor
+**Learning:** In Blazor applications, using a `<div>` wrapper with an `@onclick` handler for navigation is an accessibility anti-pattern. Screen readers do not recognize these interactive `div` elements as links or buttons, and keyboard users cannot navigate to them via `Tab` or activate them using the `Enter` key. Furthermore, this approach breaks standard browser capabilities, such as middle-clicking to open in a new tab.
+**Action:** Replace clickable `div` blocks intended for routing with semantic `<a>` tags. Apply utility classes like `text-decoration-none d-block` (and `text-dark` if needed) to ensure the anchor tag matches the original visual styling while providing native accessibility and browser features.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark d-block">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,0 +1,1 @@
+dotnet build AdvGenPriceComparer.Web/AdvGenPriceComparer.Web.csproj

--- a/test_run.sh
+++ b/test_run.sh
@@ -1,0 +1,1 @@
+dotnet test -p:EnableWindowsTargeting=true AdvGenPriceComparer.Web/AdvGenPriceComparer.Web.csproj


### PR DESCRIPTION
💡 What: Converted the `div` wrapper for item cards in Browse.razor to an `a` tag and removed the programmatic JS-like navigation. Applied text-decoration-none and text-dark classes.
🎯 Why: Using `div` with `@onclick` breaks native keyboard accessibility and blocks features like middle-clicking to open in a new tab.
♿ Accessibility: The card is now focusable via keyboard (`Tab`), can be interacted with using `Enter`, and is announced appropriately to screen readers as a link.

---
*PR created automatically by Jules for task [9287599427084602105](https://jules.google.com/task/9287599427084602105) started by @michaelleungadvgen*