### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-03-01 - Middleware Path Exclusion Bypass
+**Vulnerability:** Custom ASP.NET Core middleware (`ApiKeyMiddleware`, `RateLimitMiddleware`) used substring matching (`.Contains()`) for path exclusions (e.g., `/swagger`, `/health`), allowing attackers to bypass authentication and rate limiting by appending those strings to any request path.
+**Learning:** Using substring matching for URL path routing or authorization exclusions creates critical bypass vulnerabilities, as an attacker controls the full path and can embed the excluded string anywhere.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for path exclusions in custom middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limit middleware used `.Contains()` instead of `.StartsWith()` to exclude `/swagger` and `/health` paths.
🎯 Impact: An attacker could bypass authentication and rate limits by appending `/swagger` or `/health` to any request path.
🔧 Fix: Updated the path exclusion logic to use `.StartsWith()` for exact prefix matching.
✅ Verification: Ensure requests to protected endpoints with `/swagger` in the path now correctly return 401 Unauthorized instead of bypassing the middleware.

---
*PR created automatically by Jules for task [4740903714133862437](https://jules.google.com/task/4740903714133862437) started by @michaelleungadvgen*