### PR TITLE
🎨 Palette: Improve item card accessibility and native navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-05-21 - Accessible Links in Blazor
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like middle-click).
+**Action:** Always replace them with semantic `<a>` tags using `href` when linking to routes, applying utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }

--- a/test_browse.sh
+++ b/test_browse.sh
@@ -1,0 +1,1 @@
+cat -n AdvGenPriceComparer.Web/Components/Pages/Browse.razor | head -n 80 | tail -n 25

--- a/test_browse2.sh
+++ b/test_browse2.sh
@@ -1,0 +1,1 @@
+sed -n '73,78p' AdvGenPriceComparer.Web/Components/Pages/Browse.razor

--- a/test_browse3.sh
+++ b/test_browse3.sh
@@ -1,0 +1,1 @@
+cat -n AdvGenPriceComparer.Web/Components/Pages/Browse.razor | head -n 80 | tail -n 25


### PR DESCRIPTION
💡 What: Replaced a `<div>` with an `@onclick` navigation event in `Browse.razor` with a semantic `<a>` tag pointing directly to the item URL (`href="item/@item.Id"`). Cleaned up the unused `ViewItem` navigation method. Added utility classes `text-decoration-none text-dark` to maintain the existing visual layout.

🎯 Why: Using `<div>` elements for navigation breaks core web expectations. Users can't middle-click to open in a new tab, right-click to copy the link, or easily tab to the element using a keyboard.

♿ Accessibility: Ensures the element is natively focusable, announced as a link to screen reader users, and behaves consistently with standard web navigation.

---
*PR created automatically by Jules for task [9347345078412220698](https://jules.google.com/task/9347345078412220698) started by @michaelleungadvgen*