### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2024-03-05 - Insecure Middleware Path Matching Authorization Bypass
+**Vulnerability:** API key middleware and rate limit middleware used substring matching (`path.Contains()`) instead of prefix matching (`path.StartsWith()`) for endpoint exclusions. This enabled authorization bypass (e.g., hitting `/api/prices/upload/swagger` would incorrectly skip security checks because the path contained `/swagger`).
+**Learning:** Middleware exclusions using loose string matching create trivial bypass vulnerabilities, as attackers can easily append excluded strings to paths intended to be protected.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for middleware path exclusions in ASP.NET Core applications.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limit middlewares used loose substring matching (`Contains`) to exclude paths like `/swagger` and `/health`. This allows an attacker to bypass authentication and rate limits by appending these strings anywhere in the URL (e.g., `/api/prices/upload/swagger`).
🎯 Impact: Attackers could upload malicious data or exhaust server resources by completely bypassing API key validation and rate limiting.
🔧 Fix: Replaced `path.Contains()` with `path.StartsWith()` for all middleware exclusions to enforce strict prefix matching.
✅ Verification: Build succeeds, tests pass, and `StartsWith` correctly isolates unprotected endpoints.

---
*PR created automatically by Jules for task [2261021904934903887](https://jules.google.com/task/2261021904934903887) started by @michaelleungadvgen*