### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API key and rate limit middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-05-22 - Authorization Bypass via Substring Path Matching in Middleware
+**Vulnerability:** `ApiKeyMiddleware` and `RateLimitMiddleware` used `path.Contains("/health")` and `path.Contains("/swagger")` to bypass authentication and rate limits. An attacker could bypass these protections on sensitive endpoints by crafting a path that includes these strings (e.g., `/api/restricted/health`).
+**Learning:** Substring matching (`Contains`) on request paths for authorization logic is dangerous as it matches anywhere in the path string, not just the base route.
+**Prevention:** Always use prefix matching (`StartsWith`) or exact matching (`==`) for URL path-based exclusions in custom ASP.NET Core middleware to restrict matches strictly to the intended endpoints.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The API key and rate limiting middleware used insecure `Contains()` string matching for path exclusions (`path.Contains("/health")` and `path.Contains("/swagger")`).
🎯 **Impact:** An attacker could append or inject `/health` or `/swagger` into restricted endpoint paths (e.g., `/api/restricted/endpoint/health`), potentially bypassing authentication and rate limit requirements for those endpoints.
🔧 **Fix:** Replaced the overly broad `Contains()` matching with precise `StartsWith()` matching to correctly enforce exclusions only at the start of the intended paths.
✅ **Verification:** Verified that the project builds properly. Review the updated middleware files to confirm path matching is secure.

---
*PR created automatically by Jules for task [15923722796041759264](https://jules.google.com/task/15923722796041759264) started by @michaelleungadvgen*