### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in middleware path matching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-03-05 - Insecure Path Matching in Middleware
+**Vulnerability:** Path exclusions in custom middleware (`ApiKeyMiddleware`, `RateLimitMiddleware`) used `Contains()` instead of exact or prefix matching, allowing potential authorization and rate limit bypasses.
+**Learning:** Substring matching for paths allows malicious actors to craft URLs that contain the bypass string but route to protected endpoints (e.g., `/api/protected/swagger`), bypassing critical security checks.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) when excluding paths from security middleware in ASP.NET Core.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limiting middlewares used `Contains()` for path exclusions, which could allow attackers to bypass security controls by appending `/swagger` or `/health` to protected routes.
🎯 Impact: Attackers could potentially bypass API key validation and rate limiting on protected endpoints, leading to unauthorized access and potential denial of service.
🔧 Fix: Replaced `Contains()` with `StartsWith()` for exact prefix matching in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs`.
✅ Verification: Tested the application build to ensure middleware changes compile successfully.

---
*PR created automatically by Jules for task [5550386706719619733](https://jules.google.com/task/5550386706719619733) started by @michaelleungadvgen*