### PR TITLE
🎨 Palette: Replace div navigation with semantic anchor tags for better accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2024-05-24 - Semantic Links over Div OnClick
+**Learning:** Using `<div>` with `@onclick` for navigation in Blazor breaks keyboard accessibility and native browser features (like middle-click).
+**Action:** Always replace them with semantic `<a>` tags using `href` when linking to routes, applying utility classes like `text-decoration-none text-dark` and `style="display: block;"` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="display: block;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced a `<div>` element using `@onclick` with a semantic `<a>` tag for navigating to item details.
🎯 Why: To restore native browser features (like middle-click and right-click "Open in new tab") and improve keyboard navigation.
♿ Accessibility: Users can now naturally tab into the element and screen readers will announce it as a link.

---
*PR created automatically by Jules for task [1882243676206263846](https://jules.google.com/task/1882243676206263846) started by @michaelleungadvgen*