### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-05-18 - Auth Bypass in Custom Middleware
+**Vulnerability:** Path-based authorization and rate limit bypass in ASP.NET Core middleware caused by using substring matching (`.Contains()`) instead of exact or prefix matching (`.StartsWith()`).
+**Learning:** Using substring matching for path exclusions allows attackers to append excluded segments like `/swagger` to the end of any protected route (e.g., `/api/admin/users/swagger`), completely bypassing the middleware.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) when excluding paths in custom authorization, rate limiting, or logging middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Custom `ApiKeyMiddleware` and `RateLimitMiddleware` used `Contains("/swagger")` and `Contains("/health")` to skip validation. This allowed an attacker to bypass authentication and rate limits by appending `/swagger` or `/health` to any restricted API endpoint path (e.g., `/api/users/swagger`).
🎯 Impact: Unauthorized users could access protected API routes and bypass rate limitations, leading to unauthorized data access and potential DoS.
🔧 Fix: Replaced `.Contains()` with `.StartsWith()` to ensure only requests genuinely targeting the root paths of `/swagger` and `/health` are excluded.
✅ Verification: Ensured the code changes were applied and ran `dotnet build` and `dotnet test` successfully to guarantee that there were no regressions.

---
*PR created automatically by Jules for task [4236780964721888357](https://jules.google.com/task/4236780964721888357) started by @michaelleungadvgen*