### PR TITLE
🛡️ Sentinel: [HIGH] Fix Authorization and Rate Limit Bypass in Middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Insecure Path Matching in Custom Middleware
+**Vulnerability:** The API Key and Rate Limit middlewares were using substring matching (`.Contains()`) for exclusion paths (`/swagger`, `/health`). An attacker could bypass authentication and rate limits by appending these strings anywhere in the request URL (e.g., `/api/prices/upload?x=/health`).
+**Learning:** Using substring matching for security routing and middleware exclusions creates critical bypass vulnerabilities, as path fragments can be injected into query parameters or other path segments.
+**Prevention:** In custom ASP.NET Core middleware, always use exact matching (`==`) or prefix matching (`.StartsWith()`) for path exclusions.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API Key and Rate Limit middlewares were using substring matching (`.Contains()`) for exclusion paths (`/swagger`, `/health`). An attacker could bypass authentication and rate limits by appending these strings anywhere in the request URL (e.g., `/api/prices/upload?x=/health`).
🎯 Impact: Attackers could bypass API key authentication and rate limiting to access protected endpoints, potentially leading to unauthorized data manipulation or denial-of-service attacks.
🔧 Fix: Replaced `.Contains("/swagger")` and `.Contains("/health")` with `.StartsWith("/swagger")` and `.StartsWith("/health")` to ensure only requests genuinely targeting the root-level swagger and health endpoints bypass the middleware.
✅ Verification: Ran `dotnet build` and `dotnet test` to ensure the server compiles and passes existing test suites without regressions.

---
*PR created automatically by Jules for task [16395925752933026150](https://jules.google.com/task/16395925752933026150) started by @michaelleungadvgen*