### PR TITLE
🎨 Palette: Add confirmation dialog for delete actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-05-24 - Confirm Dialogs for Destructive Actions in Blazor
+**Learning:** In Blazor, replacing immediate destructive actions with a native browser confirmation dialog by using `IJSRuntime` (`await JSRuntime.InvokeAsync<bool>("confirm", "...")`) makes the application safer by preventing accidental data loss. Because `@onclick` supports async operations seamlessly, this can be added with no markup changes other than updating the method signature.
+**Action:** Always add a native JS confirmation dialog via `IJSRuntime` to buttons performing destructive actions like deletions.

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Items.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Items - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -186,8 +187,11 @@
         LoadItems();
     }
 
-    private void DeleteItem(Item item)
+    private async Task DeleteItem(Item item)
     {
+        bool confirm = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete '{item.Name}'?");
+        if (!confirm) return;
+
         try
         {
             WebDataService.DeleteItem(item.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/Places.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Places - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -102,8 +103,11 @@
         }
     }
 
-    private void DeletePlace(Place place)
+    private async Task DeletePlace(Place place)
     {
+        bool confirm = await JSRuntime.InvokeAsync<bool>("confirm", $"Are you sure you want to delete '{place.Name}'?");
+        if (!confirm) return;
+
         try
         {
             WebDataService.DeletePlace(place.Id);

--- a/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Admin/PriceRecords.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "Admin")]
 @inject IWebDataService WebDataService
 @inject NavigationManager Navigation
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Price Records - Admin - AdvGen PriceComparer</PageTitle>
 
@@ -192,8 +193,11 @@
         return placeCache[record.PlaceId];
     }
 
-    private void DeletePriceRecord(PriceRecord record)
+    private async Task DeletePriceRecord(PriceRecord record)
     {
+        bool confirm = await JSRuntime.InvokeAsync<bool>("confirm", "Are you sure you want to delete this price record?");
+        if (!confirm) return;
+
         try
         {
             WebDataService.DeletePriceRecord(record.Id);


### PR DESCRIPTION
💡 What: Added native JS confirmation dialogs to all 'Delete' buttons in the admin pages (Items, Places, PriceRecords).
🎯 Why: To prevent accidental data loss and provide a safer user experience during destructive actions.
📸 Before/After: N/A
♿ Accessibility: Adds a required confirmation step, giving users clear feedback on their actions.

---
*PR created automatically by Jules for task [14419781858283881626](https://jules.google.com/task/14419781858283881626) started by @michaelleungadvgen*