### PR TITLE
🛡️ Sentinel: [HIGH] Fix Authorization and Rate Limit Bypass in Middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2023-10-27 - Middleware Path Exclusion Bypass [RESOLVED]
+**Vulnerability:** Path exclusions in `ApiKeyMiddleware` and `RateLimitMiddleware` used `Contains()` (e.g. `path.Contains("/health")`). Attackers could bypass authentication and rate limits by appending an excluded string to a protected endpoint (e.g. `/api/prices/upload/health`).
+**Learning:** Using substring matching for security routing creates severe vulnerabilities, as the matching string can appear anywhere in the path.
+**Prevention:** Always use exact matching (`==`) or strict prefix matching (`StartsWith()`) for middleware path exclusions.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Middleware used `Contains()` instead of `StartsWith()` for path exclusions, which allows attackers to bypass API key validation and rate limits by appending excluded paths (e.g. `/health`) to restricted endpoints.
🎯 Impact: Attackers could freely access restricted API endpoints (like data uploads) without authentication or rate limits, potentially leading to unauthorized data modification and Denial of Service.
🔧 Fix: Changed path exclusions in `ApiKeyMiddleware` and `RateLimitMiddleware` to use exact prefix matching (`StartsWith()`).
✅ Verification: Ensured the code builds successfully, tests pass, and `StartsWith` correctly evaluates the root prefixes.

---
*PR created automatically by Jules for task [8213013398366501193](https://jules.google.com/task/8213013398366501193) started by @michaelleungadvgen*