### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in middlewares

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-27 - Auth Bypass in Middleware
+**Vulnerability:** Substring matching (`Contains`) and missing environment checks in middleware allowed bypasses.
+**Learning:** The custom middleware used `Contains` for path exclusion, which allowed bypassing by simply appending `/swagger` to any path. Furthermore, the `ApiKeyMiddleware` failed to restrict the public read access solely to the development environment.
+**Prevention:** Always use `StartsWith` or exact matches (`==`) for path exclusions and explicitly check `env.IsDevelopment()` before granting anonymous access intended only for development.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && path.StartsWith("/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Middleware used `Contains` for path exclusion, allowing bypass, and `ApiKeyMiddleware` missed `env.IsDevelopment()` check for development endpoints.
🎯 Impact: Attackers could bypass authentication and rate-limiting by appending `/swagger` or `/health` to any API path. The public endpoints were exposed in production without auth.
🔧 Fix: Replaced `Contains` with `StartsWith` in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs`, and added `env.IsDevelopment()` check.
✅ Verification: Run `dotnet build AdvGenPriceComparer.Server/AdvGenPriceComparer.Server.csproj` and run tests to verify the build and tests.

---
*PR created automatically by Jules for task [17416433826338217012](https://jules.google.com/task/17416433826338217012) started by @michaelleungadvgen*