### PR TITLE
🎨 Palette: Replace div with semantic a tag for item navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-05-27 - Semantic Navigation in Blazor
+**Learning:** Using `<div>` elements with `@onclick` for navigation in Blazor breaks keyboard accessibility and native browser features (like middle-click to open in a new tab).
+**Action:** Replace navigational `<div>` tags with semantic `<a>` tags using `href` and apply utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Replaced the clickable `div` element on the Browse page with a semantic `a` tag.\n🎯 Why: Using `div` with `@onclick` prevents native browser behaviors like middle-click to open in a new tab and breaks keyboard accessibility.\n♿ Accessibility: Users can now navigate to item details using the keyboard (Tab + Enter) and screen readers will correctly announce it as a link.

---
*PR created automatically by Jules for task [10079894823767712001](https://jules.google.com/task/10079894823767712001) started by @michaelleungadvgen*