### PR TITLE
🎨 Palette: Improve keyboard accessibility for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-05-28 - Blazor Card Navigation Accessibility
+**Learning:** Using `<div>` with `@onclick` for card-based navigation in Blazor breaks native browser accessibility features like middle-click, "Open in new tab", and keyboard navigation.
+**Action:** Replace `<div>` wrappers with semantic `<a>` tags and use `href` for routing. Apply `text-decoration-none text-dark` utility classes to preserve visual styles without breaking flexbox layouts.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Replaced the clickable `<div>` with `@onclick` navigation in `Browse.razor` with a semantic `<a href="item/@item.Id">` tag, applying `text-decoration-none text-dark` to preserve visual styling. Removed the now-unused `ViewItem` method.
🎯 Why: Using `<div>` elements for navigation breaks native browser features like right-click to "Open in new tab", middle-clicking, and basic keyboard navigability. Semantic links provide an expected user experience and properly integrate with the browser history and accessibility APIs.
♿ Accessibility: Items can now be focused using the keyboard (Tab navigation) and natively activated using Enter, fixing a significant keyboard navigation gap.

---
*PR created automatically by Jules for task [354253575333443881](https://jules.google.com/task/354253575333443881) started by @michaelleungadvgen*