### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix middleware authorization bypass via path injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-02-28 - Insecure Path Matching in Middleware [RESOLVED]
+**Vulnerability:** Path exclusions in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs` used `path.Contains("/swagger")` and `path.Contains("/health")` rather than exact matching or prefix matching. This allowed authorization bypass (e.g., accessing `/api/prices/swagger_bypass` or `/api/health_bypass`) since the restricted endpoints simply contained the excluded substring anywhere in the URL.
+**Learning:** Using `Contains()` for authorization or rate limit path exclusions is a frequent anti-pattern that creates trivial bypass vulnerabilities. Path comparisons must be exact (`==`) or use strict prefix matching (`StartsWith()`).
+**Prevention:** Always use `StartsWith()` or exact matching for middleware path exclusions to prevent unintended access via crafted URLs.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && path.StartsWith("/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Middleware excluded paths using `Contains("/swagger")`, allowing attackers to bypass API key requirements and rate limiting by appending `?path=/swagger` or accessing `/api/secure/swagger`. Additionally, the development-only `/api/prices` route did not explicitly verify the environment.
🎯 Impact: Attackers could bypass all API authentication and rate-limiting, resulting in unauthorized data access and potential Denial of Service (DoS).
🔧 Fix: Changed `Contains()` to `StartsWith()` for strict path prefix matching and added `IWebHostEnvironment.IsDevelopment()` check to the anonymous endpoints.
✅ Verification: Run `dotnet test` and attempt to access a protected endpoint by injecting `/swagger` into the route.

---
*PR created automatically by Jules for task [2232229116521415572](https://jules.google.com/task/2232229116521415572) started by @michaelleungadvgen*