### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2024-05-18 - Path Substring Matching Auth/RateLimit Bypass
+**Vulnerability:** Substring matching (`Contains()`) used for path exclusions in custom middleware (`ApiKeyMiddleware`, `RateLimitMiddleware`) allows bypassing security checks if a malicious path simply includes the excluded term anywhere in the route (e.g. `/api/admin/swagger`).
+**Learning:** Checking for substrings like `/swagger` or `/health` in `context.Request.Path` creates easily exploitable bypasses when paths are dynamically resolved or parameterized by other endpoints.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) when excluding paths from security middleware validations.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Custom middleware uses `Contains()` for path exclusions, creating a bypass risk if malicious paths include `/swagger` or `/health` as substrings (e.g., `/api/admin/swagger`).
- 🎯 Impact: Attackers could bypass API key authentication and rate limiting by appending excluded strings to restricted endpoints.
- 🔧 Fix: Replaced `Contains()` with `StartsWith()` for path exclusions in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs`.
- ✅ Verification: Ensured the application builds and tests pass. Tested path validation logic internally.

---
*PR created automatically by Jules for task [7267548434714878927](https://jules.google.com/task/7267548434714878927) started by @michaelleungadvgen*