### PR TITLE
🎨 Palette: Improve keyboard accessibility on browse page items

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-02-18 - Blazor Semantic Link Accessibility
+**Learning:** In Blazor applications, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like middle-click). It prevents screen readers from identifying elements as interactive navigation paths.
+**Action:** Always replace `<div>` with `@onclick` with semantic `<a>` tags using `href` for navigation, applying utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Replaced `<div>` with `@onclick` handler with semantic `<a>` tag for item cards on the browse page.
🎯 Why: Using divs for navigation breaks native browser features like middle-click to open in new tab and keyboard navigation.
♿ Accessibility: Users can now tab to the item cards and activate them using the keyboard, and screen readers will correctly identify them as links.

---
*PR created automatically by Jules for task [17959040599248508176](https://jules.google.com/task/17959040599248508176) started by @michaelleungadvgen*