### PR TITLE
🎨 Palette: Improve accessibility of item cards in Browse page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-02-17 - Blazor Navigation Accessibility
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like middle-click).
+**Action:** Always replace them with semantic `<a>` tags using `href` when linking to routes, applying utility classes like `text-decoration-none text-dark` to preserve visual styling without disrupting flexbox layouts.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Replaced the clickable `<div>` on item cards in the Browse page with a semantic `<a>` tag.
🎯 Why: Using `<div>` with `@onclick` breaks keyboard navigation (tabbing) and native browser behaviors like middle-clicking or right-clicking to open links in a new tab. Using an `<a>` tag fixes these accessibility and usability issues.
♿ Accessibility: Item cards are now focusable via keyboard, and screen readers will correctly identify them as links.

---
*PR created automatically by Jules for task [11337873154981226562](https://jules.google.com/task/11337873154981226562) started by @michaelleungadvgen*