### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2024-05-24 - Rate Limit & Auth Bypass via Contains
+**Vulnerability:** Path exclusion checks in API Key and Rate Limit middleware used `path.Contains("/swagger")`, allowing attackers to bypass protections simply by appending `?query=/swagger` or `/api/sensitive/swagger` to the URL.
+**Learning:** `Contains()` for path checking is a common source of authorization and rate limit bypasses. It matches substrings anywhere in the URL.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for path-based exclusions in custom ASP.NET Core middleware.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limit middleware used `.Contains("/swagger")` instead of `.StartsWith()`, allowing any request containing `/swagger` in the URL to bypass authentication and rate limits.
🎯 Impact: Attackers could append `?q=/swagger` to sensitive endpoints to bypass API key requirements and rate limiting protections.
🔧 Fix: Changed `.Contains()` to `.StartsWith()` in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs`.
✅ Verification: Ensured the project builds successfully and tests pass.

---
*PR created automatically by Jules for task [14133229564912176320](https://jules.google.com/task/14133229564912176320) started by @michaelleungadvgen*