### PR TITLE
🛡️ Sentinel: [HIGH] Fix auth and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-03-05 - Auth Bypass via Substring Path Matching
+**Vulnerability:** Path exclusion in custom middleware used `.Contains()` instead of `.StartsWith()`, allowing authentication and rate limit bypass by appending `/swagger` or `/health` to any API route. Missing environment check allowed public unauthenticated access to `/api/prices` in production.
+**Learning:** In custom ASP.NET Core middleware (e.g., `ApiKeyMiddleware`, `RateLimitMiddleware`), always use exact matching (`==`) or prefix matching (`StartsWith()`) for path exclusions. Using substring matching (`Contains()`) creates authorization and rate limit bypass vulnerabilities.
+**Prevention:** Always explicitly verify the environment using `IWebHostEnvironment.IsDevelopment()` to prevent unauthorized access in production.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && path.StartsWith("/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path exclusions in custom middleware used `.Contains()` instead of `.StartsWith()`, which allowed authentication and rate limit bypass by appending `/swagger` or `/health` to any API route. Also, public unauthenticated access to `/api/prices` was mistakenly allowed in production.
🎯 Impact: An attacker could bypass API key authentication and rate limits on any endpoint, potentially exposing sensitive data or causing a denial of service.
🔧 Fix: Changed `.Contains()` to `.StartsWith()` in path exclusions and added `env.IsDevelopment()` check for `/api/prices` public access.
✅ Verification: Verify that appending `/swagger` or `/health` to a protected route now returns 401 Unauthorized, and that `/api/prices` is protected in production environments.

---
*PR created automatically by Jules for task [364900735895991523](https://jules.google.com/task/364900735895991523) started by @michaelleungadvgen*