### PR TITLE
🎨 Palette: [UX] Improve Browse items accessibility and keyboard navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-06-03 - Replaced click-bound divs with semantic links in Blazor pages
+**Learning:** In Blazor web projects, it is a common anti-pattern to use `<div>` elements with `@onclick` handlers for navigation to detail pages. This completely breaks keyboard accessibility (no focus, no Enter key trigger) and prevents standard native browser interactions like "Right-click -> Open in new tab".
+**Action:** Always refactor these components to use semantic `<a href="...">` tags. In Bootstrap/standard UI layouts, you can easily preserve the visual appearance of the "card" by adding `text-decoration-none text-dark` utility classes and moving the `class` attributes directly onto the `<a>` tag, ensuring full accessibility without visual regressions.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -14,13 +14,13 @@
                 <div class="col-md-6">
                     <div class="input-group">
                         <span class="input-group-text"><i class="bi bi-search"></i></span>
-                        <input type="text" class="form-control" placeholder="Search items..."
+                        <input type="text" class="form-control" placeholder="Search items..." aria-label="Search items"
                                @bind="searchTerm" @bind:event="oninput" @onkeyup="HandleSearch" />
                         <button class="btn btn-primary" @onclick="ApplyFilters">Search</button>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <select class="form-select" @bind="selectedCategory">
+                    <select class="form-select" aria-label="Select category" @bind="selectedCategory">
                         <option value="">All Categories</option>
                         @foreach (var category in categories)
                         {
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="cursor: pointer;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
* 💡 What: Replaced click-bound `<div>` cards with semantic `<a>` tags and added `aria-label`s to form inputs.
* 🎯 Why: To allow native keyboard navigation, screen reader support, and standard browser features (like "Open in new tab") without breaking layout.
* ♿ Accessibility: Improved screen reader announcements and semantic HTML compliance.

---
*PR created automatically by Jules for task [8532779145813796813](https://jules.google.com/task/8532779145813796813) started by @michaelleungadvgen*