### PR TITLE
🛡️ Sentinel: [HIGH] Fix Authorization and Rate Limit Bypass in Middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-06-03 - Authorization Bypass via Substring Matching in Middleware
+**Vulnerability:** Custom ASP.NET Core middleware (`ApiKeyMiddleware`, `RateLimitMiddleware`) used `path.Contains("/swagger")` to bypass authentication and rate limits. A development-only bypass for `/api/prices` omitted the `IsDevelopment()` check.
+**Learning:** Using substring matching for path exclusions in middleware creates trivial bypasses. Attackers can embed the excluded string anywhere in the URI. Furthermore, development-only bypass comments do not secure endpoints unless programmatically enforced with `IWebHostEnvironment.IsDevelopment()`.
+**Prevention:** Always use exact matching (`==`) or prefix matching (`StartsWith()`) for path exclusions in routing and middleware. For endpoints intended only for development environments, explicitly enforce the environment check in the execution logic.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && path.StartsWith("/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key authentication and Rate Limiting could be bypassed due to insecure substring matching (`path.Contains("/swagger")`), allowing paths like `/api/admin/secureEndpoint?ignore=/swagger` to execute unprotected. Additionally, an intended development-only endpoint (`/api/prices`) lacked a check against `IWebHostEnvironment.IsDevelopment()`, exposing it publicly in production without authentication.
🎯 Impact: Attackers could bypass authentication and rate-limiting completely for any endpoint by appending matching substrings to the URL path. Unauthenticated users could read price data in production without requiring an API key.
🔧 Fix: Replaced `path.Contains` with `path.StartsWith` in both `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs`. Added an explicit `env.IsDevelopment()` check to the `InvokeAsync` method in `ApiKeyMiddleware.cs` before granting public access to `/api/prices`.
✅ Verification: Ran `dotnet build` and `dotnet test` to ensure changes compile and do not break functionality.

---
*PR created automatically by Jules for task [4743570531167178568](https://jules.google.com/task/4743570531167178568) started by @michaelleungadvgen*