### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass and environment checks in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-02-28 - Authorization and Rate Limit Bypass in Middleware
+**Vulnerability:** Middleware used substring matching (`.Contains()`) for path exclusions, creating a bypass risk, and missing environment validation for development endpoints exposed them to production.
+**Learning:** Using `Contains()` instead of precise `StartsWith()` or exact matching allows attackers to craft bypass URIs. `IWebHostEnvironment` can be injected directly into `InvokeAsync` in ASP.NET Core middleware to enable proper `IsDevelopment()` checks.
+**Prevention:** Always use exact matching or `StartsWith()` for authorization/rate limit exclusions based on path, and verify environment before enabling development bypasses.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && path.StartsWith("/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Custom middleware used substring matching (`.Contains()`) for excluded paths (e.g., Swagger, Health). Additionally, `ApiKeyMiddleware` allowed unauthenticated API access under the guise of "development only" without verifying `IWebHostEnvironment.IsDevelopment()`.
🎯 Impact: Attackers could potentially bypass API key validation and rate limiting by injecting "/swagger" or "/health" into the request path. Unauthorized parties could also access endpoints intended only for the development environment.
🔧 Fix: Changed `Contains` to `StartsWith` in both `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs` and injected `IWebHostEnvironment` into `ApiKeyMiddleware.InvokeAsync` to enforce `IsDevelopment()`.
✅ Verification: Compiled successfully and tests pass. Tested via `dotnet build` and `dotnet test` with Server filter.

---
*PR created automatically by Jules for task [10777146038354144610](https://jules.google.com/task/10777146038354144610) started by @michaelleungadvgen*