### PR TITLE
🎨 Palette: Use semantic link for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-02-18 - Semantic Navigation in Blazor
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility, screen readers and native browser features (like open in new tab).
+**Action:** Always replace them with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark d-block` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark d-block">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Changed the item card in Browse.razor from a div with @onclick to a semantic a tag.
🎯 Why: Using a div with an onclick handler breaks native browser features (open in new tab) and is less accessible.
♿ Accessibility: Improves keyboard navigation (can tab to the card and press enter) and screen reader support by using semantic HTML.

---
*PR created automatically by Jules for task [1872277136316851311](https://jules.google.com/task/1872277136316851311) started by @michaelleungadvgen*