### PR TITLE
🎨 Palette: Improve Browse page accessibility and card navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-05-24 - Improve Browse page accessibility and card navigation
+**Learning:** Using `div` elements with `@onclick` in Blazor prevents native web behaviours like right-clicking, middle-clicking to open in a new tab, and keyboard navigation.
+**Action:** Always replace `div` based navigation with semantic `a` tags (styled with `text-decoration-none text-reset`) to preserve native accessibility and web behaviors.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -14,13 +14,13 @@
                 <div class="col-md-6">
                     <div class="input-group">
                         <span class="input-group-text"><i class="bi bi-search"></i></span>
-                        <input type="text" class="form-control" placeholder="Search items..."
+                        <input type="text" class="form-control" placeholder="Search items..." aria-label="Search items"
                                @bind="searchTerm" @bind:event="oninput" @onkeyup="HandleSearch" />
                         <button class="btn btn-primary" @onclick="ApplyFilters">Search</button>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <select class="form-select" @bind="selectedCategory">
+                    <select class="form-select" @bind="selectedCategory" aria-label="Filter by category">
                         <option value="">All Categories</option>
                         @foreach (var category in categories)
                         {
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-reset">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced div-based navigation with semantic anchor tags on item cards and added ARIA labels to search/filter inputs.
🎯 Why: div elements with @onclick prevent users from opening links in a new tab, right-clicking, or using native keyboard navigation.
♿ Accessibility: Greatly improves screen reader experience by adding ARIA labels to form controls and making item cards natively focusable/navigable.

---
*PR created automatically by Jules for task [12647562449309440916](https://jules.google.com/task/12647562449309440916) started by @michaelleungadvgen*