### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2024-11-20 - Auth and Rate Limit Bypass in Middleware
+**Vulnerability:** `Contains()` in middleware path checks allows auth and rate limit bypasses (e.g., `/api/prices/upload/health`).
+**Learning:** Always use `StartsWith()` or exact matching for path exclusions in ASP.NET Core middleware to prevent unauthorized access.
+**Prevention:** Review all middleware for substring matching on request paths.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -20,7 +20,7 @@ public class ApiKeyMiddleware
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Middleware used `Contains` instead of `StartsWith` for path exclusions, allowing auth/rate-limit bypasses via query strings or arbitrary path segments.
🎯 Impact: Unauthorized actors could upload data or bypass rate limits by appending `/health` or `/swagger` to their URL path.
🔧 Fix: Changed `Contains` to `StartsWith` in `ApiKeyMiddleware.cs` and `RateLimitMiddleware.cs`.
✅ Verification: Tests run successfully and code builds without errors.

---
*PR created automatically by Jules for task [16869001899002374284](https://jules.google.com/task/16869001899002374284) started by @michaelleungadvgen*