### PR TITLE
🎨 Palette: [Improve keyboard accessibility for item links]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-06-06 - Semantic Accessibility for Blazor Navigation
+**Learning:** Using `<div>` with `@onclick` for navigation in Blazor web projects breaks keyboard accessibility and native browser features (like tab to focus, right click to open in new tab). Relative paths in hrefs can also cause path stacking issues when navigating from sub-routes.
+**Action:** Always replace them with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling without forcing block display.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }

--- a/AdvGenPriceComparer.Web/Components/Pages/Deals.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Deals.razor
@@ -52,7 +52,7 @@
                                 <small class="text-muted">
                                     <i class="bi bi-shop"></i> @deal.BestStore?.Name
                                 </small>
-                                <a href="item/@deal.Item?.Id" class="btn btn-outline-primary btn-sm">Details</a>
+                                <a href="/item/@deal.Item?.Id" class="btn btn-outline-primary btn-sm">Details</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Replaced a `<div>` element that was used for navigation with an `<a>` tag in `Browse.razor`, and updated a relative `href` in `Deals.razor` to an absolute path.
🎯 Why: `<div>` elements are not focusable by keyboard, making navigation inaccessible. Using `<a>` tags provides keyboard accessibility, native browser features (right-click, middle-click), and semantic HTML. Changing the relative path in `Deals.razor` prevents path stacking issues.
📸 Before/After: Visuals remain unchanged due to utility classes. 
♿ Accessibility: Allowed users relying on keyboard navigation (Tab and Enter keys) or screen readers to traverse and interact with item links properly.

---
*PR created automatically by Jules for task [8345022291001570859](https://jules.google.com/task/8345022291001570859) started by @michaelleungadvgen*