### PR TITLE
🎨 Palette: Improve accessibility of product cards in Browse page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-05-24 - Blazor Navigation Accessibility
+**Learning:** Using `<div>` elements with `@onclick` handlers for navigation in Blazor lists (like product cards) breaks keyboard accessibility and native browser features (like "Open in new tab").
+**Action:** Always use semantic `<a>` tags with absolute `href` paths (e.g., `/item/{id}`) for navigational elements to ensure they are accessible and behave as expected. Apply utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced `<div>` with `@onclick` handlers for navigation with semantic `<a>` tags on the Browse page.
🎯 Why: Using `<div>` for navigation breaks keyboard accessibility and native browser features like "Open in new tab". Semantic links are much more robust.
♿ Accessibility: The product cards are now accessible to keyboard users (tab order and enter to activate) and support native link behaviors.

---
*PR created automatically by Jules for task [864261728778162658](https://jules.google.com/task/864261728778162658) started by @michaelleungadvgen*