### PR TITLE
🎨 Palette: Improve accessibility and UX of item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-06-08 - Semantic Navigation in Blazor
+**Learning:** Using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like middle-click or right-click to open in new tab).
+**Action:** Always replace them with semantic `<a>` tags with absolute paths and utility classes (like `text-decoration-none text-dark`) to preserve visual styling without forcing display block.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
Added semantic anchor tags to replace div navigation in Browse.razor.
* 💡 What: Replaced `<div @onclick>` with semantic `<a>` tags on item cards.
* 🎯 Why: Enables keyboard navigation (tab focus) and native browser behaviors (middle-click, right-click to open in new tab).
* ♿ Accessibility: Improved keyboard accessibility.

---
*PR created automatically by Jules for task [18276299795285131576](https://jules.google.com/task/18276299795285131576) started by @michaelleungadvgen*