### PR TITLE
🎨 Palette: Replace div with semantic anchor for item navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-02-18 - Semantic Navigation in Blazor
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like "Open in new tab"). Screen readers don't recognize these as interactive by default.
+**Action:** Always replace `<div>` wrappers intended for navigation with semantic `<a>` tags. Ensure the `href` is set (e.g., `/item/{id}`) and apply utility classes like `text-decoration-none text-dark` to preserve visual styling while maintaining accessibility.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Replaced the clickable `<div>` with `@onclick` on the Browse page with a semantic `<a>` tag.
🎯 Why: Using a div for navigation breaks keyboard accessibility (tabbing/enter) and native browser features like right-click to open in a new tab.
📸 Before/After: Visuals should be identical due to bootstrap utility classes (`text-decoration-none text-dark`).
♿ Accessibility: Improved screen reader support by using a semantic link instead of a generic container.

---
*PR created automatically by Jules for task [4172510386792837599](https://jules.google.com/task/4172510386792837599) started by @michaelleungadvgen*