### PR TITLE
🎨 Palette: Replace onclick div with semantic anchor tag for better accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-05-28 - Semantic Navigation in Blazor
+**Learning:** In Blazor web projects, using `<div>` elements with `@onclick` handlers for navigation breaks keyboard accessibility, screen reader expectations, and native browser features like "open in new tab".
+**Action:** Always replace `<div>` with `@onclick` navigation with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark d-block` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark d-block">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What:
Replaced the `<div>` element with an `@onclick` handler in `Browse.razor` with a semantic `<a>` (anchor) tag for navigation. The associated, now-redundant `ViewItem` method in the code-behind has been removed.

🎯 Why:
Using a `div` with an `onclick` event for navigation is an anti-pattern that breaks core browser functionality. Users expect to be able to right-click -> "Open in new tab", use keyboard navigation (tabbing and pressing Enter), and have screen readers correctly identify interactive links. Semantic anchor tags provide all these features natively out-of-the-box.

📸 Before/After:
Before: The entire item card was wrapped in a `<div @onclick="() => ViewItem(item.Id)">`, capturing clicks but failing to expose link semantics to the browser.
After: The card is wrapped in a `<a href="/item/@item.Id" class="text-decoration-none text-dark d-block">`, restoring native link behavior while preserving the exact visual appearance.

♿ Accessibility:
Screen readers will now correctly announce the item cards as links. Keyboard-only users can now tab to the cards and press Enter to navigate, which was previously impossible without explicit `tabindex` and keydown event handlers.

Also documented this learning in `.jules/palette.md` to ensure future components use semantic anchor tags instead of `div` clicks for navigation.

---
*PR created automatically by Jules for task [18373788101909766394](https://jules.google.com/task/18373788101909766394) started by @michaelleungadvgen*