### PR TITLE
🎨 Palette: Replace accessible div navigation with semantic anchor tags in Browse

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2025-06-11 - Blazor Card Navigation Accessibility
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like open in new tab).
+**Action:** Always replace them with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling without forcing `display: block`.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="cursor: pointer;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 **What**:
Replaced the `<div>` element that handled item navigation via an `@onclick` event with a standard `<a>` anchor tag in `AdvGenPriceComparer.Web/Components/Pages/Browse.razor`. Removed the unused `ViewItem` method from the `@code` block.

🎯 **Why**:
Using `<div>` with `@onclick` for navigation breaks expected browser behavior and accessibility. Users cannot tab to the item card using the keyboard, and standard interactions like middle-clicking to "open in a new tab" do not work.

📸 **Before/After**:
Visually identical. The functionality now uses native semantic HTML instead of Blazor event bindings.

♿ **Accessibility**:
- Keyboard users can now Tab directly to item cards and activate them with Enter.
- Screen readers will now announce the cards correctly as links rather than un-focusable interactive elements.
- Native browser context menus (Right click -> Open in new tab) now function properly.

---
*PR created automatically by Jules for task [10625511241481471005](https://jules.google.com/task/10625511241481471005) started by @michaelleungadvgen*