### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix middleware authorization bypass via path injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2026-06-12 - Prevent Path Injection Authorization Bypass in ASP.NET Middleware
+**Vulnerability:** API Key and Rate Limit middleware used `Contains()` for path exclusions (e.g. `/swagger`) instead of exact or prefix matching, allowing attackers to bypass authentication by appending `?q=/swagger` to any endpoint. The `/api/prices` bypass lacked environment checks and used partial prefix matching.
+**Learning:** Substring matching (`Contains`) and prefix matching without a trailing slash (e.g. `StartsWith("/api/prices")`) create authorization and rate limit bypass vulnerabilities in ASP.NET custom middleware.
+**Prevention:** Always use exact matching (`==`) or prefix matching with a directory boundary (`StartsWith("/path/")`) for path exclusions. When bypassing authentication for development-only endpoints, always explicitly verify the environment using `IWebHostEnvironment.IsDevelopment()`.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path == "/api/prices" || path.StartsWith("/api/prices/")))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger") || path.StartsWith("/health") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: API Key and Rate Limit middleware used `Contains()` for path exclusions (e.g. `/swagger`), allowing attackers to bypass authentication by appending `?q=/swagger` to any endpoint. The `/api/prices` bypass lacked environment checks and used partial prefix matching.
🎯 Impact: Attackers could bypass API key authentication and rate limits to access protected endpoints or perform DoS attacks.
🔧 Fix: Switched from `Contains()` to `StartsWith()`, restricted `/api/prices` public access to Development environments only, and enforced exact (`==`) or directory (`StartsWith("/api/prices/")`) matching.
✅ Verification: Run `dotnet build` and ensure tests pass; check middleware intercepts requests without `/swagger` prefix.

---
*PR created automatically by Jules for task [5521586257465737710](https://jules.google.com/task/5521586257465737710) started by @michaelleungadvgen*