### PR TITLE
🎨 Palette: Replace onclick div with semantic anchor tag for item navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-06-03 - Accessible Navigation in Blazor
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features.
+**Action:** Always replace them with semantic `<a>` tags. Ensure the `href` uses an absolute path and apply utility classes like `text-decoration-none text-dark`.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="cursor: pointer; display: block;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced a `<div>` containing an `@onclick` handler with a semantic `<a>` tag in `Browse.razor`.
🎯 Why: To improve keyboard accessibility and enable native browser features like "open in new tab".
📸 Before/After: Visual changes are kept to a minimum by applying Bootstrap text formatting utility classes (`text-decoration-none text-dark`).
♿ Accessibility: The clickable item card can now be focused using the keyboard and interacted with natively by screen readers and users.

---
*PR created automatically by Jules for task [16476519840017583057](https://jules.google.com/task/16476519840017583057) started by @michaelleungadvgen*