### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API path exclusion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2025-06-14 - Middleware Path Exclusion Bypass via StartsWith
+**Vulnerability:** `ApiKeyMiddleware` and `RateLimitMiddleware` used `.Contains()` or `.StartsWith("/api/prices")` for path exclusions, which allows an attacker to bypass authentication/rate limits by using paths like `/api/prices_fake` or `/swagger_bypass`.
+**Learning:** Using substring matching for path exclusions in middleware creates an authorization bypass vulnerability.
+**Prevention:** In custom ASP.NET Core middleware, always use exact matching (`==`) or prefix matching with a directory boundary (`StartsWith("/path/")`) for path exclusions.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path == "/swagger" || path.StartsWith("/swagger/") || path == "/health" || path.StartsWith("/health/") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path == "/api/prices" || path.StartsWith("/api/prices/")))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path == "/swagger" || path.StartsWith("/swagger/") || path == "/health" || path.StartsWith("/health/") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: `ApiKeyMiddleware` and `RateLimitMiddleware` used `.Contains()` or `.StartsWith("/api/prices")` for path exclusions, which allows an attacker to bypass authentication/rate limits by using paths like `/api/prices_fake` or `/swagger_bypass`. Furthermore, public API read access for `/api/prices` was inadvertently granted in all environments (not just development).
* 🎯 Impact: Allows unauthorized API access or circumvention of rate limits by crafting requests with path prefixes/substrings that trick the middleware checks.
* 🔧 Fix: Used strict exact match or slash-suffixed prefix matching (`path == "/api/prices" || path.StartsWith("/api/prices/")`) and explicitly checked `IWebHostEnvironment.IsDevelopment()` before allowing public reads.
* ✅ Verification: Verified compilation via `dotnet build` and test execution via `dotnet test` with server filter.

---
*PR created automatically by Jules for task [7257514478692869106](https://jules.google.com/task/7257514478692869106) started by @michaelleungadvgen*