### PR TITLE
🎨 Palette: Semantic HTML for navigation cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-06-16 - Semantic HTML in Blazor
+**Learning:** Using `<div>` with `@onclick` for navigation in Blazor apps breaks keyboard accessibility and native browser features like right-click and "Open in new tab".
+**Action:** Replace clickable `<div>` elements used for navigation with semantic `<a>` tags, applying utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="cursor: pointer;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
### 💡 What
Replaced a clickable `<div>` used for navigation with a semantic `<a>` tag in the `Browse.razor` Blazor component, preserving its visual styling using utility classes (`text-decoration-none text-dark`). Also cleaned up the now-obsolete `ViewItem` C# method.

### 🎯 Why
In Single Page Applications like Blazor, developers often bind click events to standard blocks (`<div @onclick="...">`) to navigate between pages. However, this is an anti-pattern. While it behaves like a link to a mouse user, it lacks native link behaviors: users cannot middle-click or right-click to "Open in new tab", and it fails to display the destination URL on hover.

### 📸 Before/After
**Before:** Navigation was handled by a non-semantic `div` combined with an `@onclick` C# method acting as a programmatic router.
**After:** Navigation is driven natively by a semantic `<a>` tag with an `href` pointing directly to the item route, while remaining visually identical.

### ♿ Accessibility
This change restores full keyboard accessibility and screen reader support without requiring extensive custom ARIA roles, tabindex bindings, and specialized keypress listeners. Screen readers will now correctly announce the element as a link and communicate its destination URL.

---
*PR created automatically by Jules for task [625211854061033839](https://jules.google.com/task/625211854061033839) started by @michaelleungadvgen*