### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2024-05-18 - Path Bypasses in Custom Middleware
+**Vulnerability:** The custom ASP.NET Core middleware (`ApiKeyMiddleware`, `RateLimitMiddleware`) used `Contains("/health")` and `StartsWith("/api/prices")` for path exclusions, which created authorization and rate limit bypass vulnerabilities (e.g., `/health-check-fake`, `/api/prices-fake`).
+**Learning:** In custom ASP.NET Core middleware, using substring matching (`Contains()`) or prefix matching without a trailing slash (e.g., `StartsWith("/api/prices")`) creates significant security gaps. Always use exact matching (`==`) or prefix matching with a directory boundary (`StartsWith("/path/")`).
+**Prevention:** Always use strict path validation in middleware by explicitly checking `path == "/route"` or `path.StartsWith("/route/")` to prevent bypasses.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path == "/swagger" || path.StartsWith("/swagger/") || path == "/health" || path.StartsWith("/health/") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path == "/api/prices" || path.StartsWith("/api/prices/")))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path == "/swagger" || path.StartsWith("/swagger/") || path == "/health" || path.StartsWith("/health/") || path == "/")
         {
             await _next(context);
             return;

--- a/AdvGenPriceComparer.Tests/Server/Middleware/ApiKeyMiddlewareTests.cs
+++ b/AdvGenPriceComparer.Tests/Server/Middleware/ApiKeyMiddlewareTests.cs
@@ -1,0 +1,61 @@
+using System.Threading.Tasks;
+using AdvGenPriceComparer.Server.Middleware;
+using AdvGenPriceComparer.Server.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AdvGenPriceComparer.Tests.Server.Middleware
+{
+    public class ApiKeyMiddlewareTests
+    {
+        [Theory]
+        [InlineData("/health")]
+        [InlineData("/health/status")]
+        [InlineData("/swagger")]
+        [InlineData("/swagger/index.html")]
+        [InlineData("/")]
+        public async Task InvokeAsync_SkipsValidationForExcludedPaths(string path)
+        {
+            var nextMock = new Mock<RequestDelegate>();
+            var loggerMock = new Mock<ILogger<ApiKeyMiddleware>>();
+            var apiKeyServiceMock = new Mock<IApiKeyService>();
+            var envMock = new Mock<IWebHostEnvironment>();
+
+            var middleware = new ApiKeyMiddleware(nextMock.Object, loggerMock.Object);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+
+            await middleware.InvokeAsync(context, apiKeyServiceMock.Object, envMock.Object);
+
+            nextMock.Verify(n => n(context), Times.Once);
+        }
+
+        [Theory]
+        [InlineData("/health-fake")]
+        [InlineData("/swagger-fake")]
+        [InlineData("/api/prices-fake")]
+        public async Task InvokeAsync_RequiresApiKeyForBypassPaths(string path)
+        {
+            var nextMock = new Mock<RequestDelegate>();
+            var loggerMock = new Mock<ILogger<ApiKeyMiddleware>>();
+            var apiKeyServiceMock = new Mock<IApiKeyService>();
+            var envMock = new Mock<IWebHostEnvironment>();
+            envMock.Setup(e => e.EnvironmentName).Returns("Development");
+
+            var middleware = new ApiKeyMiddleware(nextMock.Object, loggerMock.Object);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+            context.Request.Method = "GET";
+
+            await middleware.InvokeAsync(context, apiKeyServiceMock.Object, envMock.Object);
+
+            Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+            nextMock.Verify(n => n(context), Times.Never);
+        }
+    }
+}

--- a/AdvGenPriceComparer.Tests/Server/Middleware/RateLimitMiddlewareTests.cs
+++ b/AdvGenPriceComparer.Tests/Server/Middleware/RateLimitMiddlewareTests.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using AdvGenPriceComparer.Server.Middleware;
+using AdvGenPriceComparer.Server.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AdvGenPriceComparer.Tests.Server.Middleware
+{
+    public class RateLimitMiddlewareTests
+    {
+        [Theory]
+        [InlineData("/health")]
+        [InlineData("/health/status")]
+        [InlineData("/swagger")]
+        [InlineData("/swagger/index.html")]
+        [InlineData("/")]
+        public async Task InvokeAsync_SkipsRateLimitingForExcludedPaths(string path)
+        {
+            var nextMock = new Mock<RequestDelegate>();
+            var loggerMock = new Mock<ILogger<RateLimitMiddleware>>();
+            var rateLimitServiceMock = new Mock<IRateLimitService>();
+
+            var middleware = new RateLimitMiddleware(nextMock.Object, loggerMock.Object);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+
+            await middleware.InvokeAsync(context, rateLimitServiceMock.Object);
+
+            nextMock.Verify(n => n(context), Times.Once);
+            rateLimitServiceMock.Verify(r => r.IsAllowed(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("/health-fake")]
+        [InlineData("/swagger-fake")]
+        public async Task InvokeAsync_AppliesRateLimitingForBypassPaths(string path)
+        {
+            var nextMock = new Mock<RequestDelegate>();
+            var loggerMock = new Mock<ILogger<RateLimitMiddleware>>();
+            var rateLimitServiceMock = new Mock<IRateLimitService>();
+            rateLimitServiceMock.Setup(r => r.IsAllowed(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>())).Returns(true);
+            rateLimitServiceMock.Setup(r => r.GetRemainingRequests(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>())).Returns(99);
+
+            var middleware = new RateLimitMiddleware(nextMock.Object, loggerMock.Object);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+
+            await middleware.InvokeAsync(context, rateLimitServiceMock.Object);
+
+            rateLimitServiceMock.Verify(r => r.IsAllowed(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The custom ASP.NET Core middleware (`ApiKeyMiddleware`, `RateLimitMiddleware`) used `Contains("/health")` and `StartsWith("/api/prices")` for path exclusions. This allowed attackers to bypass authentication and rate limits entirely by sending requests to trailing faked routes like `/health-fake` or `/api/prices-fake`. Furthermore, the `/api/prices` anonymous access rule lacked environmental scoping, inadvertently exposing the endpoint in production.
🎯 **Impact:** Malicious actors could completely bypass rate limiting (causing Denial of Service) and access authenticated endpoints without an API key. Production data on `/api/prices` was also exposed anonymously.
🔧 **Fix:** Replaced the loose string matching with exact path matching (`==`) and strict directory boundary matches (`.StartsWith("/route/")`). Injected `IWebHostEnvironment` into `ApiKeyMiddleware` to verify `IsDevelopment()` before allowing anonymous `/api/prices` access.
✅ **Verification:** Added `ApiKeyMiddlewareTests.cs` and `RateLimitMiddlewareTests.cs` to explicitly verify exact matches and correctly reject bypass attempts (`/health-fake`, `/api/prices-fake`). All backend tests pass.

---
*PR created automatically by Jules for task [15790334484043344963](https://jules.google.com/task/15790334484043344963) started by @michaelleungadvgen*