### PR TITLE
🎨 Palette: Replace div click handlers with semantic links for better accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2025-06-17 - Blazor Semantic Navigation
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like "Open in new tab"). It forces users to use a mouse and prevents screen readers from identifying the element as a link.
+**Action:** Always replace `<div>` with `@onclick` with semantic `<a>` tags for navigation. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
### 💡 What
Replaced `<div @onclick="() => ViewItem(item.Id)">` with semantic `<a href="/item/@item.Id">` in `AdvGenPriceComparer.Web/Components/Pages/Browse.razor`, while maintaining the original visual styling using Bootstrap utility classes (`text-decoration-none text-dark`). Unused C# click handler `ViewItem` was also removed.

### 🎯 Why
Using `<div>` with `@onclick` for navigation is an anti-pattern that breaks standard web behaviors. Replacing it with an `<a>` tag enables native browser features like "Open in new tab", "Copy link address", and mouse middle-click support, significantly improving standard usability.

### 📸 Before/After
**Before:** Interactive items behaved solely like script-driven buttons without standard hyperlink affordances.
**After:** Visually identical, but natively functions as hyperlinks in the browser.

### ♿ Accessibility
This change allows users to navigate to items using standard keyboard tabbing (`Tab` key). It also ensures screen readers will correctly identify the cards as interactive links rather than generic block elements, greatly enhancing assistive technology compatibility.

---
*PR created automatically by Jules for task [4050282686993822368](https://jules.google.com/task/4050282686993822368) started by @michaelleungadvgen*