### PR TITLE
🎨 Palette: Improve accessibility of item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-02-18 - Semantic HTML in Blazor Navigation
+**Learning:** In Blazor, attaching `@onclick` navigation events to `<div>` elements breaks native browser functionality (like "Open in new tab", "Copy link address") and impairs keyboard navigation because `<div>` elements are not inherently focusable or actionable.
+**Action:** Always replace `<div>` navigation wrappers with semantic `<a>` tags. Ensure the `href` uses absolute paths (e.g., `/item/{id}`) to prevent route stacking issues, and use utility classes like `text-decoration-none text-dark` to preserve visual card styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
* 💡 What: Replaced div wrapper with click handler to an anchor tag for item cards.
* 🎯 Why: Using div elements for navigation breaks native browser features (like open in new tab) and impairs keyboard navigation. 
* ♿ Accessibility: Improved keyboard support and accessibility by utilizing semantic html markup rather than simulated interactive elements.

---
*PR created automatically by Jules for task [5692647869372318737](https://jules.google.com/task/5692647869372318737) started by @michaelleungadvgen*