### PR TITLE
🎨 Palette: Improve accessibility of item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-02-18 - Semantic Navigation in Blazor
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like middle-click to open in new tab).
+**Action:** Always replace navigation `<div>`s with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling without forcing `display: block`.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,5 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
+
 }


### PR DESCRIPTION
💡 **What**: Replaced `<div>` with an `@onclick` handler with an `<a>` tag on the Browse page's item cards.
🎯 **Why**: Using a standard anchor tag enables native browser features like middle-clicking to open in a new tab, right-clicking for context menu, and proper link hovering.
📸 **Before/After**: N/A (Visuals remain identical thanks to utility classes).
♿ **Accessibility**: Improved keyboard accessibility, allowing users to tab to the cards and activate them using Enter, matching standard web navigation behavior.

---
*PR created automatically by Jules for task [15811122809523067279](https://jules.google.com/task/15811122809523067279) started by @michaelleungadvgen*