### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Auth and Rate Limit Bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-06-20 - Auth and Rate Limit Bypass due to Path Contains
+**Vulnerability:** API key and rate limiting middleware used `path.Contains("/swagger")` and `path.Contains("/health")`, which allowed attackers to bypass authentication and rate limits on any endpoint by simply appending `/swagger` to the URL. Also, a development bypass for `/api/prices` lacked an environment check.
+**Learning:** Using substring matching (`Contains()`) for routing exclusions is insecure. Prefix matching without directory boundary is also insecure. Always explicitly inject `IWebHostEnvironment` to check `env.IsDevelopment()` for dev bypasses.
+**Prevention:** Use exact path matching (`==`) or prefix matching with a directory boundary (`StartsWith("/path/")`). Always explicitly check `IWebHostEnvironment.IsDevelopment()` before granting dev-only access.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path.StartsWith("/api/prices/") || path == "/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: API key and rate limiting middleware used `path.Contains("/swagger")` and `path.Contains("/health")`, which allowed attackers to bypass authentication and rate limits on any endpoint by simply appending `/swagger` to the URL. Also, a development bypass for `/api/prices` lacked an environment check.
🎯 Impact: Attackers could easily bypass API key authentication and rate limiting to access protected endpoints without authorization or limits.
🔧 Fix: Replaced insecure `.Contains()` calls with strict boundary prefix matching (`StartsWith("/swagger/") || path == "/swagger"`) in both `ApiKeyMiddleware` and `RateLimitMiddleware`. Injected `IWebHostEnvironment` into `ApiKeyMiddleware` and explicitly verified `env.IsDevelopment()` for the `/api/prices` bypass, and bounded the `/api/prices` check with trailing slashes.
✅ Verification: Ran `dotnet build` and `dotnet test` to confirm compilation and existing logic still functions correctly. Tests passed. Checked file diffs to verify strict matching implementation.

---
*PR created automatically by Jules for task [2781353611844223395](https://jules.google.com/task/2781353611844223395) started by @michaelleungadvgen*