### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Message Leak

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2026-06-21 - Exception Message Information Leakage
+**Vulnerability:** API endpoints and health checks returned raw `Exception.Message` values directly to the client (e.g., in `HealthCheckController.cs` and `PricesController.cs`).
+**Learning:** Returning raw exception messages from database or internal service layers can leak sensitive infrastructure details, file paths, or schema information to potential attackers. Internal logs should capture the detailed exception, while the client should receive a safe, generic message.
+**Prevention:** Always log the full exception internally (e.g., via `ILogger`) and return a generic error message (like "An internal error occurred") to the API consumer. Do not interpolate `ex.Message` into HTTP responses.

--- a/AdvGenPriceComparer.Server/Controllers/HealthCheckController.cs
+++ b/AdvGenPriceComparer.Server/Controllers/HealthCheckController.cs
@@ -170,7 +170,7 @@ public class HealthController : ControllerBase
             {
                 Status = "Unhealthy",
                 ResponseTimeMs = stopwatch.ElapsedMilliseconds,
-                Error = $"Database connection failed: {ex.Message}"
+                Error = "Database connection failed."
             };
         }
     }

--- a/AdvGenPriceComparer.Server/Controllers/PricesController.cs
+++ b/AdvGenPriceComparer.Server/Controllers/PricesController.cs
@@ -58,7 +58,7 @@ public class PricesController : ControllerBase
             return BadRequest(new UploadResult
             {
                 Success = false,
-                ErrorMessage = $"Internal error: {ex.Message}"
+                ErrorMessage = "An internal error occurred while processing the request."
             });
         }
     }

--- a/AdvGenPriceComparer.Server/Services/PriceDataService.cs
+++ b/AdvGenPriceComparer.Server/Services/PriceDataService.cs
@@ -12,11 +12,13 @@ public class PriceDataService : IPriceDataService
 {
     private readonly PriceDataContext _context;
     private readonly INotificationService _notificationService;
+    private readonly ILogger<PriceDataService> _logger;
 
-    public PriceDataService(PriceDataContext context, INotificationService notificationService)
+    public PriceDataService(PriceDataContext context, INotificationService notificationService, ILogger<PriceDataService> logger)
     {
         _context = context;
         _notificationService = notificationService;
+        _logger = logger;
     }
 
     public async Task<IEnumerable<SharedItem>> GetItemsAsync(ItemFilter? filter = null, int page = 1, int pageSize = 100)
@@ -357,8 +359,9 @@ public class PriceDataService : IPriceDataService
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Error processing data upload");
             result.Success = false;
-            result.ErrorMessage = ex.Message;
+            result.ErrorMessage = "An internal error occurred during the upload process.";
             session.IsSuccess = false;
             session.ErrorMessage = ex.Message;
             await _context.UploadSessions.AddAsync(session);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Internal exception messages were being returned in API responses and health checks.
🎯 Impact: Potential information disclosure revealing underlying stack details, path strings, or database context errors to attackers.
🔧 Fix: Replaced raw `ex.Message` outputs in the API layer with generic error messages while preserving internal logging via ILogger.
✅ Verification: Verified the server compiles and standard tests pass after applying the privacy-safe error handlers.

---
*PR created automatically by Jules for task [7026679160978018043](https://jules.google.com/task/7026679160978018043) started by @michaelleungadvgen*