### PR TITLE
🛡️ Sentinel: [HIGH] Fix API Key Authorization & Rate Limit Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2026-06-22 - Auth Bypass via Substring Matching & Missing Environment Check [RESOLVED]
+**Vulnerability:** Middleware used `.Contains("/health")` and `.StartsWith("/api/prices")` (without trailing slash), and failed to check `env.IsDevelopment()` before granting anonymous access, leading to API key and rate limit bypasses in production.
+**Learning:** Development bypasses left in production and substring route matching are high-impact API vulnerabilities.
+**Prevention:** Always explicitly verify `IWebHostEnvironment.IsDevelopment()` when bypassing auth for dev endpoints, and use exact `==` or directory boundary `StartsWith("/path/")` matches for paths.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path == "/swagger" || path.StartsWith("/swagger/") || path == "/health" || path.StartsWith("/health/") || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path == "/api/prices" || path.StartsWith("/api/prices/")))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path == "/swagger" || path.StartsWith("/swagger/") || path == "/health" || path.StartsWith("/health/") || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The `ApiKeyMiddleware` and `RateLimitMiddleware` used loose substring matching (`.Contains("/health")` and `.StartsWith("/api/prices")` without trailing slashes) to skip validation. The anonymous read access to `/api/prices` endpoints did not verify if the environment was development before bypassing API key checks.
**🎯 Impact:** Attackers could bypass authentication and rate limits entirely by prepending or appending matching strings to sensitive endpoints (e.g., `/api/prices/admin-delete`, `/swagger-bypass-auth`), leading to unauthorized data access and potential Denial of Service (DoS) in production.
**🔧 Fix:** Replaced `.Contains()` with exact matching (`==`) or strict directory boundaries (`StartsWith("/path/")`), and added `IWebHostEnvironment.env.IsDevelopment()` check before permitting anonymous GET access.
**✅ Verification:** Compiled project `AdvGenPriceComparer.Server` to verify correct environment injection and syntax. Ran global test suite. Verified code changes restrict bypasses correctly.

---
*PR created automatically by Jules for task [6810817838628862571](https://jules.google.com/task/6810817838628862571) started by @michaelleungadvgen*