### PR TITLE
🎨 Palette: Semantic links for item cards

### DIFF
--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced the `div` element acting as a card with a semantic `a` (anchor) tag in `AdvGenPriceComparer.Web/Components/Pages/Browse.razor`. I also removed the now-unused `ViewItem` C# method that previously handled the routing.

🎯 Why: Using a `div` element with an `@onclick` event handler for navigation breaks native browser behaviors (such as "Right-click -> Open in new tab", middle-clicking, or hover link preview). It also limits keyboard navigation since a basic `div` doesn't naturally receive focus like a standard anchor tag. 

♿ Accessibility: Anchor tags are inherently focusable and semantic, greatly improving accessibility for screen reader users and keyboard navigation. Using a standard `<a>` tag ensures the control is properly announced as a link to assistive technologies, making it much more intuitive to use.

---
*PR created automatically by Jules for task [3941567486554230239](https://jules.google.com/task/3941567486554230239) started by @michaelleungadvgen*