### PR TITLE
🎨 Palette: Improve Browse card keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-06-23 - Blazor Card Clickability Accessibility
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility (tabbing) and native browser features (like middle-click or right-click "Open in new tab").
+**Action:** Always replace them with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling without forcing `display: block`.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
**💡 What**
Replaced the `<div>` wrapper with an `<a>` tag for the item cards on the Browse page.

**🎯 Why**
Previously, the card used a `div` with an `@onclick` handler. This breaks native browser features (like "Open in new tab") and prevents users who rely on keyboards from tabbing to and activating the card. Using semantic anchor tags restores standard browser link behavior.

**♿ Accessibility**
- Item cards are now fully focusable via the keyboard (`Tab`).
- Screen readers will now correctly identify the cards as interactive links instead of generic content blocks.
- Users can now use standard modifier keys (e.g., Ctrl+Click or Middle-Click) to open items in new tabs.

---
*PR created automatically by Jules for task [2032369272583677791](https://jules.google.com/task/2032369272583677791) started by @michaelleungadvgen*