### PR TITLE
🎨 Palette: Improve Browse card accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+## 2026-06-24 - Accessible Clickable Cards in Blazor
+**Learning:** Using `<div @onclick="...">` for navigation cards breaks keyboard accessibility (tabbing, screen readers) and prevents native browser behaviors like middle-click or 'open in new tab'.
+**Action:** Always use semantic `<a>` tags with an `href` for navigation. Apply utility classes like `text-decoration-none text-dark` to preserve card styling without breaking accessibility or layout.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Converted `div`-based clickable item cards to semantic `<a>` tags in the Browse page.
🎯 Why: The `div @onclick` pattern breaks basic web expectations—users couldn't middle-click to open items in a new tab, and it prevented native keyboard navigation (tabbing).
♿ Accessibility: Items in the Browse page are now fully keyboard accessible (can be tabbed to and activated with Enter) and semantically correct for screen readers, while preserving the existing card layout and hover styling.

---
*PR created automatically by Jules for task [12395243705265480672](https://jules.google.com/task/12395243705265480672) started by @michaelleungadvgen*