### PR TITLE
🎨 Palette: Make item cards accessible via keyboard navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-06-25 - Blazor Keyboard Accessibility Navigation
+**Learning:** In Blazor web projects, using `<div>` elements with `@onclick` for navigation breaks keyboard accessibility (tab navigation and "Enter" to click) and native browser features (open in new tab).
+**Action:** Always replace navigation `<div>` tags with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced the interactive `<div @onclick>` used for navigation in `Browse.razor` with a semantic `<a>` anchor tag.
🎯 Why: Using a generic `<div>` with a click event handler breaks keyboard accessibility (tab navigation and hitting "Enter" to click) and breaks native browser features (like right-clicking or middle-clicking to open in a new tab).
♿ Accessibility: Item cards can now be navigated to via the keyboard using `Tab` and `Enter`, natively supporting screen readers and proper focus management.

---
*PR created automatically by Jules for task [7336670774249046210](https://jules.google.com/task/7336670774249046210) started by @michaelleungadvgen*