### PR TITLE
🎨 Palette: Make item cards accessible via semantic anchor tags

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-06-26 - Blazor Div Navigation Accessibility
+**Learning:** Using `<div>` elements with `@onclick` for navigation in Blazor apps breaks keyboard accessibility and native browser features. It is a recurring accessibility anti-pattern.
+**Action:** Always use semantic `<a>` tags for navigation, applying utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
**💡 What:**
Replaced the `<div>` wrapper with an `@onclick` handler on item cards in the "Browse" page (`Browse.razor`) with a semantic `<a>` anchor tag linking to `/item/{id}`.

**🎯 Why:**
Using a `<div>` with an `@onclick` event for primary navigation completely breaks keyboard accessibility and native browser features (like right-click -> "Open in new tab"). It forces screen reader users and keyboard-only users to guess the interaction, leading to a poor and inaccessible experience.

**📸 Before/After:**
*(Visual styling remains unchanged, as utility classes were used to preserve layout and typography.)*

**♿ Accessibility:**
- Keyboard users can now naturally Tab into the item cards and press Enter to navigate.
- Screen readers will now announce the cards properly as links rather than generic, non-interactive elements.
- The `ViewItem` C# method was removed as the navigation logic is now seamlessly handled natively by the HTML anchor.

---
*PR created automatically by Jules for task [2470713877766592229](https://jules.google.com/task/2470713877766592229) started by @michaelleungadvgen*