### PR TITLE
🎨 Palette: Improve keyboard accessibility for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-06-27 - Semantic navigation in Blazor
+**Learning:** Using `<div>` elements with `@onclick` for navigation in Blazor components prevents native browser behaviors (open in new tab, copy link) and breaks keyboard accessibility, as they aren't natively focusable or operable with the Enter key.
+**Action:** Always replace interactive navigation `<div>`s with semantic `<a>` anchor tags. Apply utility classes like `text-decoration-none text-dark` to preserve visual styling. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to avoid relative path stacking issues.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 **What**: Changed the item card in `Browse.razor` from a clickable `<div>` with an `@onclick` handler to a semantic `<a>` tag.
🎯 **Why**: Using a `<div>` for navigation breaks native browser features (like right-clicking to open in a new tab) and is terrible for keyboard accessibility because `<div>` elements are not natively focusable and don't respond to the Enter key.
♿ **Accessibility**: By using an `<a>` tag, the item card is now natively focusable via the Tab key, can be activated using the Enter key, and is correctly announced by screen readers as a link.

---
*PR created automatically by Jules for task [2365571631212511617](https://jules.google.com/task/2365571631212511617) started by @michaelleungadvgen*