### PR TITLE
🎨 Palette: Semantic navigation for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-05-23 - Keyboard Accessibility in Blazor Web Apps
+**Learning:** In Blazor web projects, using `<div>` elements with `@onclick` handlers for navigation breaks standard keyboard accessibility and native browser features (like "Open in new tab").
+**Action:** Always replace `<div>` elements meant for navigation with semantic `<a>` anchor tags. Apply utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark" style="cursor: pointer;">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
* 💡 What: Replaced `<div>` with `@onclick` with a semantic `<a>` tag for navigation in Browse page.
* 🎯 Why: Using a `<div>` with `@onclick` breaks keyboard accessibility and native browser features like "Open in new tab".
* ♿ Accessibility: The item card can now be focused using the keyboard (Tab) and activated with the Enter key, improving screen reader and keyboard user experience.

---
*PR created automatically by Jules for task [456393632190001449](https://jules.google.com/task/456393632190001449) started by @michaelleungadvgen*