### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization and rate limit bypass in middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+
+## 2026-06-30 - Path Matching and Environment Check Bypasses in Middleware
+**Vulnerability:** Middleware paths were checked using `Contains()` instead of exact matching, allowing arbitrary paths with substrings (e.g., `/api/data?q=/swagger`) to bypass authentication and rate limits. Additionally, a development-only exception for `/api/prices` lacked a check for `IWebHostEnvironment.IsDevelopment()`, exposing it in production.
+**Learning:** In ASP.NET Core custom middleware, `Contains()` for path exclusions is inherently insecure. Also, dependency injection via the `InvokeAsync` parameter list can be used to inject services like `IWebHostEnvironment` directly without modifying the constructor.
+**Prevention:** Always use exact matching (`==`) or strict prefix matching (`StartsWith("/path/")`) with directory boundaries for exclusions. Always explicitly verify the environment using `IWebHostEnvironment.IsDevelopment()` when creating dev-only bypasses.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path.StartsWith("/api/prices/") || path == "/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: API Key authentication and Rate Limiting middlewares used insecure `Contains` substring matching for path exclusions, allowing authorization and rate-limit bypasses on arbitrary endpoints by simply appending `/swagger` or `/health` to the path or query. Furthermore, an anonymous access bypass intended for development lacked the `IsDevelopment()` check, exposing `/api/prices` without authentication in production.

🎯 Impact: An attacker could bypass API authentication and rate limits to access protected resources, scrape data, or cause Denial of Service by constructing malicious URLs containing the excluded substrings.

🔧 Fix: Replaced `Contains()` with exact path matching and `StartsWith` directory boundaries. Injected `IWebHostEnvironment` into `ApiKeyMiddleware.InvokeAsync` to explicitly check `IsDevelopment()` before allowing anonymous access.

✅ Verification: Run `dotnet test AdvGenPriceComparer.Tests/AdvGenPriceComparer.Tests.csproj -p:EnableWindowsTargeting=true` to verify compilation and tests pass.

---
*PR created automatically by Jules for task [446298292985217549](https://jules.google.com/task/446298292985217549) started by @michaelleungadvgen*