### PR TITLE
🎨 Palette: Improve keyboard accessibility for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-02-18 - Semantic HTML in Blazor for Keyboard Nav
+**Learning:** In Blazor applications, wrapping interactive elements (like cards) in `<div>` with `@onclick` breaks keyboard navigation (tabbing and Enter/Space to click) and native browser features (like "Open in new tab").
+**Action:** Always replace `<div @onclick="Action">` with semantic `<a href="route">` tags. Use utility classes like `text-decoration-none text-dark` to preserve the visual appearance of the element without forcing display property changes that break layouts (like `d-block` on Bootstrap cards).

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -14,13 +14,13 @@
                 <div class="col-md-6">
                     <div class="input-group">
                         <span class="input-group-text"><i class="bi bi-search"></i></span>
-                        <input type="text" class="form-control" placeholder="Search items..."
+                        <input type="text" class="form-control" placeholder="Search items..." aria-label="Search items"
                                @bind="searchTerm" @bind:event="oninput" @onkeyup="HandleSearch" />
                         <button class="btn btn-primary" @onclick="ApplyFilters">Search</button>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <select class="form-select" @bind="selectedCategory">
+                    <select class="form-select" aria-label="Filter by category" @bind="selectedCategory">
                         <option value="">All Categories</option>
                         @foreach (var category in categories)
                         {
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 What: Replaced the `<div @onclick>` wrapper with a semantic `<a>` tag for item cards and added `aria-label` attributes to the search inputs in `Browse.razor`.
🎯 Why: Wrapping interactive components in `div` elements with custom `@onclick` handlers breaks native keyboard navigation (cannot tab or press Enter) and native browser behaviors (cannot middle-click to open in new tab). The semantic `<a>` tag properly inherits all browser navigation features natively.
📸 Before/After: Visuals remain unchanged due to adding `text-decoration-none text-dark` to the `<a>` tag to prevent default blue underlining.
♿ Accessibility: Item cards are now fully navigable via keyboard (tabbed focus) and readable by screen readers as links, and search inputs are properly labelled for screen readers.

---
*PR created automatically by Jules for task [13512140626476535300](https://jules.google.com/task/13512140626476535300) started by @michaelleungadvgen*