### PR TITLE
🎨 Palette: Improve keyboard accessibility for item cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-07-01 - Keyboard Accessibility in Blazor
+**Learning:** In Blazor web projects using Bootstrap, converting a `div` element with `@onclick` to an `<a>` anchor tag is crucial for keyboard accessibility. However, it's important to ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling.
+**Action:** Always replace `<div @onclick="...">` with semantic `<a href="...">` tags for navigation elements in Blazor to ensure full keyboard navigation support and native browser features.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
**💡 What**: Converted the `div` element acting as a clickable item card in `Browse.razor` to a semantic `<a>` anchor tag. Removed the redundant `ViewItem` method as the navigation is now handled natively via the `href` attribute. Applied Bootstrap utility classes to preserve the original visual styling.

**🎯 Why**: The previous implementation used a `div` with an `@onclick` handler for navigation. This approach broke keyboard accessibility (users could not tab to the cards and press Enter to navigate) and prevented native browser features (like right-clicking to open the link in a new tab).

**📸 Before/After**: Visually, the cards remain identical. Functionally, they are now focusable, navigable via keyboard, and behave as standard links.

**♿ Accessibility**: Significantly improved keyboard navigation by ensuring that all interactive elements are reachable via the Tab key and can be activated using standard keyboard interactions (Enter). Also ensures better screen reader compatibility by using semantic HTML tags for navigation.

---
*PR created automatically by Jules for task [2158135243555015738](https://jules.google.com/task/2158135243555015738) started by @michaelleungadvgen*