### PR TITLE
🛡️ Sentinel: [HIGH] Fix Authorization and Rate Limit Bypass in Middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2025-07-03 - Fix Authorization and Rate Limit Path Bypass
+**Vulnerability:** Path substring matching (e.g., `path.Contains("/swagger")`) in custom middleware allowed attackers to bypass authentication and rate limits on protected endpoints simply by appending `/swagger` to the URL. Additionally, development bypass logic was executing in production due to a missing environment check.
+**Learning:** When developing custom routing or middleware exclusions in ASP.NET Core, path matching must be exact or use strict prefix matching with directory boundaries. Furthermore, dependencies like `IWebHostEnvironment` can be injected directly into middleware `InvokeAsync` parameters.
+**Prevention:** Always use `StartsWith("/path/") || == "/path"` for middleware exclusions, never `Contains()`. Ensure development-only overrides explicitly check `IWebHostEnvironment.IsDevelopment()`.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path.StartsWith("/api/prices/") || path == "/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path substring matching (e.g., `path.Contains("/swagger")`) in custom middleware allowed attackers to bypass authentication and rate limits on protected endpoints simply by appending `/swagger` or `/health` to the URL. Additionally, development bypass logic for `/api/prices` was executing in production due to a missing environment check.
🎯 Impact: Attackers could bypass API key authentication and rate limiting entirely for any endpoint by appending specific strings, gaining unauthorized access to sensitive data and potentially causing denial of service. The `/api/prices` endpoint was also incorrectly exposed to anonymous users in production.
🔧 Fix: Replaced all `.Contains()` path checks with exact matching (`==`) or strict prefix matching (`.StartsWith("/path/")`) with directory boundaries in both `ApiKeyMiddleware` and `RateLimitMiddleware`. Injected `IWebHostEnvironment` into `ApiKeyMiddleware` and added an `env.IsDevelopment()` check to the `/api/prices` bypass.
✅ Verification: Ensure the application builds successfully and that all tests in `AdvGenPriceComparer.Tests` pass using `dotnet test AdvGenPriceComparer.Tests/AdvGenPriceComparer.Tests.csproj -p:EnableWindowsTargeting=true`. You can also manually verify that appending `/swagger` to a protected URL returns a 401 Unauthorized response instead of allowing access.

---
*PR created automatically by Jules for task [6725339989490077181](https://jules.google.com/task/6725339989490077181) started by @michaelleungadvgen*