### PR TITLE
🎨 Palette: Make browse item cards keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-07-03 - Replaced div @onclick with a tag for item cards
+**Learning:** In Blazor web projects using Bootstrap 5, replacing a `<div class="card" @onclick...>` with an `<a href... class="card text-decoration-none text-dark">` improves keyboard accessibility (allowing tab navigation and 'open in new tab') without breaking the flexbox layout, whereas adding `d-block` would override the `.card` flex-direction.
+**Action:** Always use semantic `<a>` tags instead of `<div>` with `@onclick` for navigation in Blazor to ensure native browser features and accessibility are preserved.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>


### PR DESCRIPTION
💡 What: Replaced the non-semantic `<div @onclick>` with a standard `<a href>` tag for item cards on the Browse page.
🎯 Why: Using `<div>` elements for navigation prevents users from opening items in a new tab (middle-click or Ctrl+click) and breaks standard native browser features.
♿ Accessibility: Converting the click target to an anchor tag enables proper keyboard navigation (tabbing), focus states, and works seamlessly with screen readers without requiring custom JavaScript event handlers.

---
*PR created automatically by Jules for task [14314995904940422510](https://jules.google.com/task/14314995904940422510) started by @michaelleungadvgen*