### PR TITLE
🛡️ Sentinel: [HIGH] Fix Authorization and Rate Limit bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,11 @@
 - Graceful fallback for non-Windows platforms (returns plaintext for tests)
 **Learning:** Local application settings stored in AppData are often treated as "secure enough" by developers, but they remain highly vulnerable to local credential theft if unencrypted.
 **Prevention:** Always encrypt sensitive settings (like API keys, passwords, or tokens) at rest. For Windows desktop applications, utilize `System.Security.Cryptography.ProtectedData` (DPAPI) bound to the `CurrentUser` scope, which seamlessly encrypts data using the user's OS credentials.
+## 2026-07-04 - Fixed Rate Limit and Authorization Bypass in Middleware
+**Vulnerability:** Authorization and Rate Limiting bypass was possible via the  method matching trailing parameters (e.g., ).
+**Learning:** Using  or similar substring matching in ASP.NET Core middleware creates an implicit bypass vulnerability, as the substring could occur anywhere in the request path.
+**Prevention:** Always use strict path prefix matching (e.g., ) or exact string matches when attempting to bypass security middleware for specific routes.
+## 2023-11-09 - Fixed Rate Limit and Authorization Bypass in Middleware
+**Vulnerability:** Authorization and Rate Limiting bypass was possible via the `Contains` method matching trailing parameters (e.g., `?param=/swagger`).
+**Learning:** Using `path.Contains("/swagger")` or similar substring matching in ASP.NET Core middleware creates an implicit bypass vulnerability, as the substring could occur anywhere in the request path.
+**Prevention:** Always use strict path prefix matching (e.g., `path.StartsWith("/swagger/") || path == "/swagger"`) or exact string matches when attempting to bypass security middleware for specific routes.

--- a/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/ApiKeyMiddleware.cs
@@ -16,18 +16,18 @@ public class ApiKeyMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService)
+    public async Task InvokeAsync(HttpContext context, IApiKeyService apiKeyService, IWebHostEnvironment env)
     {
         // Skip API key validation for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;
         }
 
         // Allow anonymous access in development for certain endpoints
-        if (context.Request.Method == "GET" && path.StartsWith("/api/prices"))
+        if (env.IsDevelopment() && context.Request.Method == "GET" && (path.StartsWith("/api/prices/") || path == "/api/prices"))
         {
             // Public read access
             await _next(context);

--- a/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
+++ b/AdvGenPriceComparer.Server/Middleware/RateLimitMiddleware.cs
@@ -20,7 +20,7 @@ public class RateLimitMiddleware
     {
         // Skip rate limiting for Swagger and health endpoints
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
-        if (path.Contains("/swagger") || path.Contains("/health") || path == "/")
+        if (path.StartsWith("/swagger/") || path == "/swagger" || path.StartsWith("/health/") || path == "/health" || path == "/")
         {
             await _next(context);
             return;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Authorization and Rate Limiting bypass was possible via the `Contains` method matching trailing parameters (e.g., `?param=/swagger`).
🎯 Impact: Attackers could bypass API key authentication and rate limits on protected endpoints by simply appending `?param=/swagger` or `?param=/health` to the URL.
🔧 Fix: Replaced `path.Contains("/swagger")` with strict prefix matching (`StartsWith("/swagger/") || path == "/swagger"`) in both `ApiKeyMiddleware` and `RateLimitMiddleware`. Added `IWebHostEnvironment` injection to `ApiKeyMiddleware` to strictly enforce `env.IsDevelopment()` for public GET access to `/api/prices`.
✅ Verification: Compiled successfully and `AdvGenPriceComparer.Tests` suite passes. Verified via `dotnet test AdvGenPriceComparer.Tests/AdvGenPriceComparer.Tests.csproj -p:EnableWindowsTargeting=true`. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11093740590935883771](https://jules.google.com/task/11093740590935883771) started by @michaelleungadvgen*