### PR TITLE
🎨 Palette: Improve accessibility of item cards

### DIFF
--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -215,10 +215,5 @@
     {
         currentPage = page;
         LoadItems();
-    }
-
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
     }
 }


### PR DESCRIPTION
💡 **What**
Changed the item cards on the Browse page from interactive `<div>` elements with `@onclick` handlers to standard semantic `<a>` anchor tags. 

🎯 **Why**
Using `<div>` elements for primary navigation breaks expected web patterns. Users could not right-click to copy the link or open it in a new tab, and middle-clicking was broken. Furthermore, interactive `<div>` elements without explicit keyboard handling are often bypassed or improperly handled by assistive technologies.

📸 **Before/After**
*Visual appearance remains strictly identical.* Applied Bootstrap 5 `text-decoration-none text-dark` utility classes to the new `<a>` tags to prevent them from rendering with the default blue underline, perfectly maintaining the original design system style while fixing the underlying DOM semantics.

♿ **Accessibility**
- Improved semantic HTML: Screen readers now correctly identify the cards as navigable links rather than generic, interactive groupings.
- Keyboard Navigation: Natively supports focusing via `Tab` and activation via `Enter` without requiring custom event handlers.
- Native Browser Support: Restores native interactions (Right Click -> Open in New Tab, Middle Click, Copy Link Address).

---
*PR created automatically by Jules for task [17078557308026481562](https://jules.google.com/task/17078557308026481562) started by @michaelleungadvgen*