### PR TITLE
🎨 Palette: Improve accessibility for item navigation by using semantic anchor tags

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2026-07-05 - Semantic Navigation in Blazor
+**Learning:** Using `<div>` elements with `@onclick` for navigation in Blazor breaks keyboard accessibility, disables screen reader link announcements, and prevents native browser features like "Open in new tab".
+**Action:** Always replace `<div>` elements intended for navigation with semantic `<a>` anchor tags, use absolute paths (e.g., `/item/{id}`), and apply utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
**💡 What:**
Replaced the `<div>` tag with the `@onclick` handler used for navigating to an item detail view with a standard HTML `<a>` tag in `Browse.razor`. I also removed the C# `ViewItem` method that became redundant as the URL is set natively on the `href`.

**🎯 Why:**
Using a standard `a` tag inherently allows standard browser behaviors (such as opening links in a new tab via right-click or middle-click), providing a better and standard user experience across all devices.

**📸 Before/After:**
Visuals stay exactly the same. Only underlying semantic HTML changes. The link retains the visual structure of a card using existing bootstrap utility classes `text-decoration-none text-dark` and no new custom CSS classes were added.

**♿ Accessibility:**
Screen readers will now properly announce the card as a link and where it's pointing to. Plus, keyboard accessibility defaults into behavior out of the box because `<a>` tags are inherently focusable and actionable with the 'Enter' key, meaning we no longer need to implement custom key handlers for non-mouse users.

---
*PR created automatically by Jules for task [9865340510506609159](https://jules.google.com/task/9865340510506609159) started by @michaelleungadvgen*