### PR TITLE
🎨 Palette: Semantic Navigation for Browse Item Cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2025-07-07 - Semantic Navigation in Blazor
+**Learning:** In Blazor web projects, using `<div>` with `@onclick` for navigation breaks keyboard accessibility and native browser features (like "Open in new tab").
+**Action:** Always replace them with semantic `<a>` tags. Ensure the `href` uses an absolute path (e.g., `/item/{id}`) to prevent relative path stacking issues, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling without forcing `display: block`.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Replaced a `<div>` wrapper using an `@onclick` handler on the Browse page item cards with a semantic `<a>` tag pointing to the absolute path `/item/{id}`. The obsolete `ViewItem` method in the code-behind block was also removed.

🎯 Why: Using `<div>` elements with JavaScript (`@onclick`) for navigation is a well-known anti-pattern. It breaks native browser features (like middle-clicking or right-clicking to "Open in new tab") and creates unnecessary coupling with the C# code-behind block for simple routing.

📸 Before/After: Visual appearance remains exactly the same, but the element is now natively a link.

♿ Accessibility: Native `<a>` tags are significantly better for screen readers and keyboard accessibility compared to click-handled `<div>` elements, ensuring that users navigating via keyboard can easily focus and interact with the item cards.

---
*PR created automatically by Jules for task [3126264957910226239](https://jules.google.com/task/3126264957910226239) started by @michaelleungadvgen*