### PR TITLE
🎨 Palette: Improve keyboard navigation and screen reader accessibility on Browse page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 **Learning:** In WPF applications using `ui:Button` and `ui:SymbolIcon`, relying solely on the `ToolTip` attribute is insufficient for screen readers. Icon-only buttons lack proper text representation without explicitly defining an ARIA label.
 **Action:** Always define `AutomationProperties.Name` on icon-only buttons to ensure they are fully accessible to screen readers, just like using `aria-label` in web development.
 
+
+## 2024-07-08 - Blazor Semantic Links for Accessibility
+**Learning:** In Blazor web projects using Bootstrap, using a `<div @onclick="Action">` for navigation breaks keyboard accessibility and native browser features (like open in new tab).
+**Action:** Always replace `div` based navigation with semantic `<a>` tags. Use absolute paths (`href="/item/{id}"`) to prevent relative path stacking, and apply utility classes like `text-decoration-none text-dark` to preserve visual styling.

--- a/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
+++ b/AdvGenPriceComparer.Web/Components/Pages/Browse.razor
@@ -13,14 +13,14 @@
             <div class="row g-3">
                 <div class="col-md-6">
                     <div class="input-group">
-                        <span class="input-group-text"><i class="bi bi-search"></i></span>
-                        <input type="text" class="form-control" placeholder="Search items..."
+                        <span class="input-group-text"><i class="bi bi-search" aria-hidden="true"></i></span>
+                        <input type="text" class="form-control" placeholder="Search items..." aria-label="Search items"
                                @bind="searchTerm" @bind:event="oninput" @onkeyup="HandleSearch" />
                         <button class="btn btn-primary" @onclick="ApplyFilters">Search</button>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <select class="form-select" @bind="selectedCategory">
+                    <select class="form-select" @bind="selectedCategory" aria-label="Filter by category">
                         <option value="">All Categories</option>
                         @foreach (var category in categories)
                         {
@@ -58,7 +58,7 @@
             @foreach (var item in items)
             {
                 <div class="col">
-                    <div class="card h-100 shadow-sm item-card" @onclick="() => ViewItem(item.Id)" style="cursor: pointer;">
+                    <a href="/item/@item.Id" class="card h-100 shadow-sm item-card text-decoration-none text-dark">
                         <div class="card-body">
                             <h5 class="card-title">@item.Name</h5>
                             @if (!string.IsNullOrEmpty(item.Brand))
@@ -73,7 +73,7 @@
                         <div class="card-footer bg-transparent text-center">
                             <small class="text-muted">Click for details</small>
                         </div>
-                    </div>
+                    </a>
                 </div>
             }
         </div>
@@ -217,8 +217,4 @@
         LoadItems();
     }
 
-    private void ViewItem(string itemId)
-    {
-        Navigation.NavigateTo($"/item/{itemId}");
-    }
 }


### PR DESCRIPTION
💡 What: Converted the item card `div` with `@onclick` into a semantic `<a>` tag (`href="/item/@item.Id"`), applied Bootstrap classes (`text-decoration-none text-dark`) to preserve visual styling, and added missing `aria-label` and `aria-hidden` attributes to the search input, filter select, and decorative search icon.
🎯 Why: `div` elements with click handlers are not accessible via keyboard (Tab/Enter) and break native browser functionalities like "Open in new tab" or copying the link address. Screen readers also require semantic tags and proper ARIA labels to announce interactive form controls and structure.
♿ Accessibility: 
- Item cards are now fully focusable and navigable via keyboard.
- Screen readers will correctly announce the search input field and category filter dropdown.
- The decorative search icon is explicitly hidden from assistive technologies.

---
*PR created automatically by Jules for task [3211516210925597198](https://jules.google.com/task/3211516210925597198) started by @michaelleungadvgen*